### PR TITLE
fix $.security.crypto to be not function

### DIFF
--- a/modules/api/api-xsjs/src/main/resources/META-INF/dirigible/kronos/security/security.js
+++ b/modules/api/api-xsjs/src/main/resources/META-INF/dirigible/kronos/security/security.js
@@ -52,7 +52,7 @@ class XSCrypto {
 		if (data instanceof ArrayBuffer) {
 			data = fromBufferToArray(data);
 		}
-		const javaBytes = Java.type("com.sap.xsk.xssecurestore.ds.facade.XSKSecureCryptoFacade").md5(data, key);
+		const javaBytes = Java.type("com.codbex.kronos.xssecurestore.ds.facade.SecureCryptoFacade").md5(data, key);
 		return fromArrayToBuffer(javaBytes);
 	}
 
@@ -60,7 +60,7 @@ class XSCrypto {
 		if (data instanceof ArrayBuffer) {
 			data = fromBufferToArray(data);
 		}
-		const javaBytes = Java.type("com.sap.xsk.xssecurestore.ds.facade.XSKSecureCryptoFacade").sha1(data, key);
+		const javaBytes = Java.type("com.codbex.kronos.xssecurestore.ds.facade.SecureCryptoFacade").sha1(data, key);
 		return fromArrayToBuffer(javaBytes);
 	}
 
@@ -68,7 +68,7 @@ class XSCrypto {
 		if (data instanceof ArrayBuffer) {
 			data = fromBufferToArray(data);
 		}
-		const javaBytes = Java.type("com.sap.xsk.xssecurestore.ds.facade.XSKSecureCryptoFacade").sha256(data, key);
+		const javaBytes = Java.type("com.codbex.kronos.xssecurestore.ds.facade.SecureCryptoFacade").sha256(data, key);
 		return fromArrayToBuffer(javaBytes);
 	}
 }

--- a/modules/api/api-xsjs/src/main/resources/META-INF/dirigible/kronos/security/security.js
+++ b/modules/api/api-xsjs/src/main/resources/META-INF/dirigible/kronos/security/security.js
@@ -46,21 +46,43 @@ exports.Store = function (filePath) {
     }
 }
 
-exports.crypto = function (){
-    return new XSCrypto()
+class XSCrypto {
 
+	md5(data, key) {
+		if (data instanceof ArrayBuffer) {
+			data = fromBufferToArray(data);
+		}
+		const javaBytes = Java.type("com.sap.xsk.xssecurestore.ds.facade.XSKSecureCryptoFacade").md5(data, key);
+		return fromArrayToBuffer(javaBytes);
+	}
+
+	sha1(data, key) {
+		if (data instanceof ArrayBuffer) {
+			data = fromBufferToArray(data);
+		}
+		const javaBytes = Java.type("com.sap.xsk.xssecurestore.ds.facade.XSKSecureCryptoFacade").sha1(data, key);
+		return fromArrayToBuffer(javaBytes);
+	}
+
+	sha256(data, key) {
+		if (data instanceof ArrayBuffer) {
+			data = fromBufferToArray(data);
+		}
+		const javaBytes = Java.type("com.sap.xsk.xssecurestore.ds.facade.XSKSecureCryptoFacade").sha256(data, key);
+		return fromArrayToBuffer(javaBytes);
+	}
 }
 
-class XSCrypto {
-    CryptoFacade = Java.type("com.codbex.kronos.xssecurestore.ds.facade.SecureCryptoFacade");
+exports.crypto = new XSCrypto();
 
-    md5(data,key){
-        return this.CryptoFacade.md5(data,key);
-    }
-    sha1(data,key){
-        return this.CryptoFacade.sha1(data,key);
-    }
-    sha256(data,key){
-        return this.CryptoFacade.sha256(data,key);
-    }
+// From ArrayBuffer to byte[]
+function fromBufferToArray(buffer) {
+	return Array.from(new Uint8Array(buffer))
+}
+
+// from Java byte[]  to JS ArrayBuffer
+function fromArrayToBuffer(javaBytes) {
+	var uint8Array = new Uint8Array(javaBytes.length);
+	uint8Array.set(Java.from(javaBytes));
+	return uint8Array.buffer
 }


### PR DESCRIPTION
Fix ```$.security.crypto``` not to be a function, and methods of ```$.security.crypto```  to accept/return ArrayBuffer as is mentioned in [XS Classic JavaScript API Reference](https://help.sap.com/doc/3de842783af24336b6305a3c0223a369/2.0.03/en-US/$.security.crypto.html)
Fixes:
- #15
- #14 

From:
- https://github.com/SAP-archive/xsk/issues/1744
- https://github.com/SAP-archive/xsk/issues/1745