### PR TITLE
revert: use servlets 9.4 as 11 does not work on tomcat 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -314,7 +314,7 @@
     <derby.version>10.12.1.1</derby.version>
     <activemq.version>5.14.5</activemq.version>
     <jsr250-api.version>1.0</jsr250-api.version>
-    <jetty.version>11.0.11</jetty.version>
+    <jetty.version>9.4.12.v20180830</jetty.version>
     <lucene.version>7.0.1</lucene.version>
     <chemistry.version>1.1.0</chemistry.version>
     <flowable.version>6.3.0</flowable.version>


### PR DESCRIPTION
Jetty Servlets should not be updated to a major version above 9, as it would require a newer version of Tomcat too