### PR TITLE
fix: fix import paths for mjs files and revert broken dependency

### DIFF
--- a/modules/engines/engine-xsjs/src/main/resources/META-INF/dirigible/exports/XSJSLibExportsGenerator.mjs
+++ b/modules/engines/engine-xsjs/src/main/resources/META-INF/dirigible/exports/XSJSLibExportsGenerator.mjs
@@ -1,8 +1,8 @@
-import { XSJSLibCompiler } from '/exports/XSJSLibCompiler.mjs'
-import { XSJSLibStateTable } from '/exports/XSJSLibStateTable.mjs'
-import { digest } from '@dirigible-v4/utils'
-import { repository } from '@dirigible-v4/platform'
-import { bytes } from '@dirigible-v4/io'
+import { XSJSLibCompiler } from './XSJSLibCompiler.mjs'
+import { XSJSLibStateTable } from './XSJSLibStateTable.mjs'
+import { digest } from '@dirigible/utils'
+import { repository } from '@dirigible/platform'
+import { bytes } from '@dirigible/io'
 
 const ProblemsFacade = Java.type('org.eclipse.dirigible.api.v3.problems.ProblemsFacade');
 

--- a/modules/engines/engine-xsjs/src/main/resources/META-INF/dirigible/exports/XSJSLibRunner.mjs
+++ b/modules/engines/engine-xsjs/src/main/resources/META-INF/dirigible/exports/XSJSLibRunner.mjs
@@ -10,7 +10,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import { XSJSLibExportsGenerator } from '/exports/XSJSLibExportsGenerator.mjs'
+import { XSJSLibExportsGenerator } from './XSJSLibExportsGenerator.mjs'
 const stateTableParams = {
   name: __context.stateTableName,
   schema: "PUBLIC"

--- a/modules/engines/engine-xsjs/src/main/resources/META-INF/dirigible/exports/XSJSLibStateTable.mjs
+++ b/modules/engines/engine-xsjs/src/main/resources/META-INF/dirigible/exports/XSJSLibStateTable.mjs
@@ -1,6 +1,6 @@
-import { dao } from '@dirigible-v4/db'
-import { query } from '@dirigible-v4/db'
-import { digest } from '@dirigible-v4/utils'
+import { dao } from '@dirigible/db'
+import { query } from '@dirigible/db'
+import { digest } from '@dirigible/utils'
 
 export class XSJSLibStateTable {
   tableName = "";

--- a/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/kronos/exports/tests/XSJSLibCompilerTest.mjs
+++ b/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/kronos/exports/tests/XSJSLibCompilerTest.mjs
@@ -1,6 +1,6 @@
 import { assertEquals } from '../utils/utils.mjs'
-import { XSJSLibCompiler } from '/exports/XSJSLibCompiler.mjs'
-import { repository } from '@dirigible-v4/platform'
+import { XSJSLibCompiler } from './XSJSLibCompiler.mjs'
+import { repository } from '@dirigible/platform'
 
 function testContentModifier_AcornSimpleContentModification() {
   const compiler = new XSJSLibCompiler();

--- a/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/kronos/exports/tests/XSJSLibExportGeneratorMultiFileTest.mjs
+++ b/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/kronos/exports/tests/XSJSLibExportGeneratorMultiFileTest.mjs
@@ -1,9 +1,9 @@
 import { assertEquals } from '../utils/utils.mjs'
 import { getParams } from '../utils/stateTableParamsProvider.mjs'
 import { fetchAllEntriesInTable } from '../utils/utils.mjs'
-import { XSJSLibExportsGenerator } from '/exports/XSJSLibExportsGenerator.mjs'
-import { repository } from '@dirigible-v4/platform'
-import { digest } from '@dirigible-v4/utils'
+import { XSJSLibExportsGenerator } from './XSJSLibExportsGenerator.mjs'
+import { repository } from '@dirigible/platform'
+import { digest } from '@dirigible/utils'
 const XSJSLibSynchronizerRegistryEntity = Java.type("com.codbex.kronos.synchronizer.XSJSLibSynchronizerRegistryEntity");
 
 function testMultiFileFolderExportGeneration() {

--- a/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/kronos/exports/tests/XSJSLibExportGeneratorSingleFileModifyTest.mjs
+++ b/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/kronos/exports/tests/XSJSLibExportGeneratorSingleFileModifyTest.mjs
@@ -1,9 +1,9 @@
 import { assertEquals } from '../utils/utils.mjs'
 import { getParams } from '../utils/stateTableParamsProvider.mjs'
 import { fetchAllEntriesInTable } from '../utils/utils.mjs'
-import { XSJSLibExportsGenerator } from '/exports/XSJSLibExportsGenerator.mjs'
-import { repository } from '@dirigible-v4/platform'
-import { digest } from '@dirigible-v4/utils'
+import { XSJSLibExportsGenerator } from './XSJSLibExportsGenerator.mjs'
+import { repository } from '@dirigible/platform'
+import { digest } from '@dirigible/utils'
 const XSJSLibSynchronizerRegistryEntity = Java.type("com.codbex.kronos.synchronizer.XSJSLibSynchronizerRegistryEntity");
 
 function testSingleFileModificationAndExportGeneration() {

--- a/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/kronos/exports/tests/XSJSLibExportGeneratorSingleFileTest.mjs
+++ b/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/kronos/exports/tests/XSJSLibExportGeneratorSingleFileTest.mjs
@@ -1,9 +1,9 @@
 import { assertEquals } from '../utils/utils.mjs'
 import { getParams } from '../utils/stateTableParamsProvider.mjs'
 import { fetchAllEntriesInTable } from '../utils/utils.mjs'
-import { XSJSLibExportsGenerator } from '/exports/XSJSLibExportsGenerator.mjs'
-import { repository } from '@dirigible-v4/platform'
-import { digest } from '@dirigible-v4/utils'
+import { XSJSLibExportsGenerator } from './XSJSLibExportsGenerator.mjs'
+import { repository } from '@dirigible/platform'
+import { digest } from '@dirigible/utils'
 const XSJSLibSynchronizerRegistryEntity = Java.type("com.codbex.kronos.synchronizer.XSJSLibSynchronizerRegistryEntity");
 
 function testSingleFileExportGeneration() {

--- a/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/kronos/exports/tests/XSJSLibExportsGeneratorIsContentChangedTest.mjs
+++ b/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/kronos/exports/tests/XSJSLibExportsGeneratorIsContentChangedTest.mjs
@@ -1,8 +1,8 @@
 import { assertEquals } from '../utils/utils.mjs'
 import { getParams } from '../utils/stateTableParamsProvider.mjs'
-import { XSJSLibExportsGenerator } from '/exports/XSJSLibExportsGenerator.mjs'
-import { digest } from '@dirigible-v4/utils'
-import { repository } from '@dirigible-v4/platform'
+import { XSJSLibExportsGenerator } from './XSJSLibExportsGenerator.mjs'
+import { digest } from '@dirigible/utils'
+import { repository } from '@dirigible/platform'
 
 function isContentChangedTest() {
   const stateTableParams = getParams();

--- a/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/kronos/exports/tests/XSJSLibStateTableFindTest.mjs
+++ b/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/kronos/exports/tests/XSJSLibStateTableFindTest.mjs
@@ -1,7 +1,7 @@
 import { assertEquals } from '../utils/utils.mjs'
 import { getParams } from '../utils/stateTableParamsProvider.mjs'
-import { XSJSLibStateTable } from '/exports/XSJSLibStateTable.mjs'
-import { digest } from '@dirigible-v4/utils'
+import { XSJSLibStateTable } from './XSJSLibStateTable.mjs'
+import { digest } from '@dirigible/utils'
 
 function findTableTest() {
   // create new state table

--- a/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/kronos/exports/tests/XSJSLibStateTableUpdateTest.mjs
+++ b/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/kronos/exports/tests/XSJSLibStateTableUpdateTest.mjs
@@ -1,8 +1,8 @@
 import { assertEquals } from '../utils/utils.mjs'
 import { getParams } from '../utils/stateTableParamsProvider.mjs'
 import { fetchAllEntriesInTable } from '../utils/utils.mjs'
-import { XSJSLibStateTable } from '/exports/XSJSLibStateTable.mjs'
-import { digest } from '@dirigible-v4/utils'
+import { XSJSLibStateTable } from './XSJSLibStateTable.mjs'
+import { digest } from '@dirigible/utils'
 
 function updateTableTest() {
   // create new state table

--- a/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/kronos/exports/tests/XSJSLibStateTableWriteTest.mjs
+++ b/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/kronos/exports/tests/XSJSLibStateTableWriteTest.mjs
@@ -1,8 +1,8 @@
 import { assertEquals } from '../utils/utils.mjs'
 import { getParams } from '../utils/stateTableParamsProvider.mjs'
 import { fetchAllEntriesInTable } from '../utils/utils.mjs'
-import { XSJSLibStateTable } from '/exports/XSJSLibStateTable.mjs'
-import { digest } from '@dirigible-v4/utils'
+import { XSJSLibStateTable } from './XSJSLibStateTable.mjs'
+import { digest } from '@dirigible/utils'
 
 function writeTableTest() {
   // create new state table

--- a/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/kronos/exports/utils/createTableHelper.mjs
+++ b/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/kronos/exports/utils/createTableHelper.mjs
@@ -1,5 +1,5 @@
-import { XSJSLibStateTable } from '/exports/XSJSLibStateTable.mjs'
-import { repository } from '@dirigible-v4/platform'
+import { XSJSLibStateTable } from './XSJSLibStateTable.mjs'
+import { repository } from '@dirigible/platform'
 
 let stateTableParams = {
   name: "PROCESSED_XSJSLIB_ARTEFACTS",

--- a/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/kronos/exports/utils/utils.mjs
+++ b/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/kronos/exports/utils/utils.mjs
@@ -1,4 +1,4 @@
-import { query } from '@dirigible-v4/db'
+import { query } from '@dirigible/db'
 
 var assert = require('utils/assert');
 

--- a/pom.xml
+++ b/pom.xml
@@ -314,7 +314,7 @@
     <derby.version>10.12.1.1</derby.version>
     <activemq.version>5.14.5</activemq.version>
     <jsr250-api.version>1.0</jsr250-api.version>
-    <jetty.version>11.0.11</jetty.version>
+    <jetty.version>9.4.12.v20180830</jetty.version>
     <lucene.version>7.0.1</lucene.version>
     <chemistry.version>1.1.0</chemistry.version>
     <flowable.version>6.3.0</flowable.version>


### PR DESCRIPTION
These changes were required because ES6 imports should follow the spec and the JS executor no longer supports absolute path imports and @dirigible-v{N}/{api}.

