### PR TITLE
Do not fail when artifacts like views, tables, synonyms, etc. exist

### DIFF
--- a/components/engine-commons/src/main/java/com/codbex/kronos/utils/CommonsUtils.java
+++ b/components/engine-commons/src/main/java/com/codbex/kronos/utils/CommonsUtils.java
@@ -10,16 +10,14 @@
  */
 package com.codbex.kronos.utils;
 
+import com.codbex.kronos.exceptions.ArtifactParserException;
+import com.codbex.kronos.parser.models.BaseParserErrorsModel;
 import java.util.ArrayList;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.codbex.kronos.exceptions.ArtifactParserException;
-import com.codbex.kronos.parser.models.BaseParserErrorsModel;
 
 /**
  * The Class CommonsUtils.
@@ -131,16 +129,14 @@ public class CommonsUtils {
         if (errorList.size() > 0) {
             for (BaseParserErrorsModel errorModel : errorList) {
                 try {
-                    logger.error("Parser error at file: {}, line: {}, position: {}, symbol: {}", location, errorModel.getLine(),
-                            errorModel.getCharPositionInLine(), errorModel.getOffendingSymbol());
-                    logger.error(errorModel.getMsg());
+                    logger.error("Parser error at file: [{}], line: [{}], position: [{}], symbol: [{}]. Message: [{}]", location,
+                            errorModel.getLine(), errorModel.getCharPositionInLine(), errorModel.getOffendingSymbol(), errorModel.getMsg());
                     // ProblemsFacade.save(location, errorType, Integer.toString(errorModel.getLine()),
                     // Integer.toString(errorModel.getCharPositionInLine()), errorModel.getOffendingSymbol(),
                     // errorModel.getMsg(), artifactType, CommonsConstants.MODULE_PARSERS,
                     // CommonsConstants.SOURCE_PUBLISH_REQUEST, CommonsConstants.PROGRAM_KRONOS);
-                } catch (Exception e) {
-                    logger.error("There is an issue with logging of the Errors.");
-                    logger.error(e.getMessage());
+                } catch (Exception ex) {
+                    logger.error("There is an issue with logging of the Errors.", ex);
                 }
             }
             throw new ArtifactParserException(String.format(
@@ -166,13 +162,12 @@ public class CommonsUtils {
     public static void logCustomErrors(String location, String errorType, String line, String column, String errorMessage, String expected,
             String category, String module, String source, String program) {
         try {
-            logger.error("Parser error at file: {}, type: {}, line: {}, column: {}, module: {}", location, errorType, line, column, module);
-            logger.error(errorMessage);
+            logger.error("Parser error at file: [{}], type: [{}], line: [{}], column: [{}], module: [{}]. Message: [{}]", location,
+                    errorType, line, column, module, errorMessage);
             // ProblemsFacade.save(location, errorType, line, column, errorMessage, expected, category, module,
             // source, program);
-        } catch (Exception e) {
-            logger.error("There is an issue with logging of the Errors.");
-            logger.error(e.getMessage());
+        } catch (Exception ex) {
+            logger.error("There is an issue with logging of the Errors.", ex);
         }
     }
 
@@ -186,14 +181,13 @@ public class CommonsUtils {
      */
     public static void logProcessorErrors(String errorMessage, String errorType, String location, String artifactType) {
         try {
-            logger.error("Parser error at file: {}, type: {}, artefacts: {}", location, errorType, artifactType);
-            logger.error(errorMessage);
+            logger.error("Parser error at file: [{}], type: [{}], artefacts: [{}]. Message: [{}]", location, errorType, artifactType,
+                    errorMessage);
             // ProblemsFacade.save(location, errorType, "", "", errorMessage, "", artifactType,
             // CommonsConstants.MODULE_PROCESSORS, CommonsConstants.SOURCE_PUBLISH_REQUEST,
             // CommonsConstants.PROGRAM_KRONOS);
-        } catch (Exception e) {
-            logger.error("There is an issue with logging of the Errors.");
-            logger.error(e.getMessage());
+        } catch (Exception ex) {
+            logger.error("There is an issue with logging of the Errors.", ex);
         }
     }
 
@@ -204,7 +198,8 @@ public class CommonsUtils {
      * @return the string[]
      */
     public static String[] extractArtifactNameWhenSchemaIsProvided(String artifactName) {
-        Pattern pattern = Pattern.compile("\"?(.*?)\"?\\.\"(.*?)\"", Pattern.CASE_INSENSITIVE);
+        Pattern pattern = Pattern.compile(".*\"([^\"]+)\"\\.\"([^\"]+)\".*", Pattern.CASE_INSENSITIVE);
+
         Matcher matcher = pattern.matcher(artifactName.trim());
         boolean matchFound = matcher.find();
         if (matchFound) {

--- a/components/engine-hdb/pom.xml
+++ b/components/engine-hdb/pom.xml
@@ -17,6 +17,10 @@
   <dependencies>
     <dependency>
       <groupId>com.codbex.kronos</groupId>
+      <artifactId>codbex-kronos-commons</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.codbex.kronos</groupId>
       <artifactId>codbex-kronos-components-engine-commons</artifactId>
     </dependency>
     <dependency>

--- a/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/parser/HDBParameters.java
+++ b/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/parser/HDBParameters.java
@@ -10,7 +10,7 @@
  */
 package com.codbex.kronos.engine.hdb.parser;
 
-import java.nio.charset.StandardCharsets;
+import com.codbex.kronos.commons.StringUtils;
 
 /**
  * The Class HDBParameters.
@@ -60,7 +60,7 @@ public class HDBParameters {
     public HDBParameters(String type, String location, byte[] content, String workspacePath) {
         this.type = type;
         this.location = location;
-        this.content = new String(content, StandardCharsets.UTF_8);
+        this.content = StringUtils.toString(content);
         this.workspacePath = workspacePath;
     }
 

--- a/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/parser/HDBUtils.java
+++ b/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/parser/HDBUtils.java
@@ -216,6 +216,7 @@ public class HDBUtils {
         if (indexOfBracket > -1 && indexOfEndOfProcKeyword > -1) {
             String procNameWithWhiteSymbols = content.substring(indexOfEndOfProcKeyword, indexOfBracket);
             return procNameWithWhiteSymbols.replace("\\s", "")
+                                           .replaceAll("\"", "")
                                            .trim();
         }
         String errMsg = "HDB Table Function file not correct";

--- a/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/processors/AbstractHDBProcessor.java
+++ b/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/processors/AbstractHDBProcessor.java
@@ -10,15 +10,13 @@
  */
 package com.codbex.kronos.engine.hdb.processors;
 
+import com.codbex.kronos.engine.hdb.api.IHDBProcessor;
+import com.codbex.kronos.engine.hdb.domain.HDBDataStructure;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.codbex.kronos.engine.hdb.api.IHDBProcessor;
-import com.codbex.kronos.engine.hdb.domain.HDBDataStructure;
 
 /**
  * The Class AbstractHDBProcessor.
@@ -39,12 +37,8 @@ public abstract class AbstractHDBProcessor<T extends HDBDataStructure> implement
      */
     public void executeSql(String sql, Connection connection) throws SQLException {
         try (PreparedStatement statement = connection.prepareStatement(sql)) {
-            logger.info(sql);
+            logger.info("Executing SQL: [{}]", sql);
             statement.executeUpdate();
-        } catch (SQLException e) {
-            logger.error(sql);
-            logger.error(e.getMessage(), e);
-            throw e;
         }
     }
 }

--- a/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/processors/HDBProcedureDropProcessor.java
+++ b/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/processors/HDBProcedureDropProcessor.java
@@ -10,18 +10,21 @@
  */
 package com.codbex.kronos.engine.hdb.processors;
 
+import com.codbex.kronos.engine.hdb.domain.HDBProcedure;
+import com.codbex.kronos.engine.hdb.parser.Constants;
+import com.codbex.kronos.utils.CommonsConstants;
+import com.codbex.kronos.utils.CommonsUtils;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.eclipse.dirigible.database.sql.DatabaseArtifactTypes;
 import org.eclipse.dirigible.database.sql.ISqlDialect;
 import org.eclipse.dirigible.database.sql.SqlFactory;
 import org.eclipse.dirigible.database.sql.dialects.hana.HanaSqlDialect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.codbex.kronos.engine.hdb.domain.HDBProcedure;
-import com.codbex.kronos.engine.hdb.parser.Constants;
-import com.codbex.kronos.utils.CommonsConstants;
-import com.codbex.kronos.utils.CommonsUtils;
 
 /**
  * The Class HDBProcedureDropProcessor.
@@ -30,6 +33,8 @@ public class HDBProcedureDropProcessor extends AbstractHDBProcessor<HDBProcedure
 
     /** The Constant logger. */
     private static final Logger logger = LoggerFactory.getLogger(HDBProcedureDropProcessor.class);
+
+    private static final Pattern SCHEMA_PATTERN = Pattern.compile(".*PROCEDURE \"([^\"]+)\"\\.\"([^\"]+)\".*", Pattern.CASE_INSENSITIVE);
 
     /**
      * Execute.
@@ -42,32 +47,58 @@ public class HDBProcedureDropProcessor extends AbstractHDBProcessor<HDBProcedure
     public void execute(Connection connection, HDBProcedure procedureModel) throws SQLException {
         logger.info("Processing Drop Procedure: " + procedureModel.getName());
         String procedureNameWithoutSchema = CommonsUtils.extractArtifactNameWhenSchemaIsProvided(procedureModel.getName())[1];
-        procedureModel.setSchema(CommonsUtils.extractArtifactNameWhenSchemaIsProvided(procedureModel.getName())[0]);
+        procedureModel.setSchema(extractSchema(procedureModel.getContent()).orElse(null));
 
-        if (SqlFactory.getNative(connection)
-                      .exists(connection, procedureNameWithoutSchema, DatabaseArtifactTypes.PROCEDURE)) {
-            ISqlDialect dialect = SqlFactory.deriveDialect(connection);
-            if (!(dialect.getClass()
-                         .equals(HanaSqlDialect.class))) {
-                String errorMessage = String.format("Procedures are not supported for %s", dialect.getDatabaseName(connection));
-                CommonsUtils.logProcessorErrors(errorMessage, CommonsConstants.PROCESSOR_ERROR, procedureModel.getLocation(),
-                        CommonsConstants.HDB_PROCEDURE_PARSER);
-                throw new IllegalStateException(errorMessage);
-            }
-            String sql = Constants.HDBPROCEDURE_DROP + procedureModel.getName();
-            try {
-                executeSql(sql, connection);
-                String message = String.format("Drop procedure [%s] successfully", procedureModel.getName());
-                logger.info(message);
-            } catch (SQLException ex) {
-                String message = String.format("Drop procedure[%s] skipped due to an error: %s", procedureModel, ex.getMessage());
-                CommonsUtils.logProcessorErrors(message, CommonsConstants.PROCESSOR_ERROR, procedureModel.getLocation(),
-                        CommonsConstants.HDB_PROCEDURE_PARSER);
-                throw ex;
-            }
-        } else {
-            String warningMessage = String.format("Procedure [%s] does not exists during the drop process", procedureModel.getName());
-            logger.warn(warningMessage);
+        if (!SqlFactory.getNative(connection)
+                       .exists(connection, procedureModel.getSchema(), procedureNameWithoutSchema, DatabaseArtifactTypes.PROCEDURE)) {
+            logger.warn("Procedure [{}}] in schema [{}] does not exists during the drop process", procedureModel.getName(),
+                    procedureModel.getSchema());
+            return;
         }
+        ISqlDialect dialect = SqlFactory.deriveDialect(connection);
+        if (!(dialect.getClass()
+                     .equals(HanaSqlDialect.class))) {
+            String errorMessage = String.format("Procedures are not supported for %s", dialect.getDatabaseName(connection));
+            CommonsUtils.logProcessorErrors(errorMessage, CommonsConstants.PROCESSOR_ERROR, procedureModel.getLocation(),
+                    CommonsConstants.HDB_PROCEDURE_PARSER);
+            throw new IllegalStateException(errorMessage);
+        }
+        String sql = null == procedureModel.getSchema()
+                ? (Constants.HDBPROCEDURE_DROP + dialect.getEscapeSymbol() + procedureModel.getName() + dialect.getEscapeSymbol())
+                : (Constants.HDBPROCEDURE_DROP + dialect.getEscapeSymbol() + procedureModel.getSchema() + dialect.getEscapeSymbol() + "."
+                        + dialect.getEscapeSymbol() + procedureModel.getName() + dialect.getEscapeSymbol());
+        try {
+            executeSql(sql, connection);
+            logger.info("Drop procedure [{}] in schema [{}] successfully", procedureModel.getName(), procedureModel.getSchema());
+        } catch (SQLException ex) {
+            String message = String.format("Drop procedure[%s] skipped due to an error: %s", procedureModel, ex.getMessage());
+            CommonsUtils.logProcessorErrors(message, CommonsConstants.PROCESSOR_ERROR, procedureModel.getLocation(),
+                    CommonsConstants.HDB_PROCEDURE_PARSER);
+            throw ex;
+        }
+    }
+
+    private Optional<String> extractSchema(String content) {
+        Matcher matcher = SCHEMA_PATTERN.matcher(content);
+        return matcher.find() ? Optional.of(matcher.group(1)) : Optional.empty();
+    }
+
+    public static void main(String[] args) {
+        String str = "PROCEDURE \"AF477A06D\".\"com.apotest.jpk.backend.customizing.procedures::updateP_13_3\" (\n" + "    \n"
+                + "    IN new_ \"com.apotest.jpk.backend.customizing.model::custTables.P_13_3_tab\",\n"
+                + "    IN old_ \"com.apotest.jpk.backend.customizing.model::custTables.P_13_3_tab\",\n"
+                + "    OUT error \"com.apotest.jpk.backend.customizing.model::custTypes.tt_error\"\n" + "    \n" + ")\n"
+                + "   LANGUAGE SQLSCRIPT\n" + "   SQL SECURITY INVOKER\n" + "   DEFAULT SCHEMA AF477A06D\n" + "   AS\n" + "BEGIN\n"
+                + "\tdeclare lv_P_13_3 string;\n" + "\tdeclare lv_idxInvoiceConf Integer;\n" + "\tdeclare lv_idx Integer;\n" + "\t\n"
+                + "\t select \"idx\", \"idxInvoiceConf\", \"taxCode\"\n" + "        into lv_idx, lv_idxInvoiceConf, lv_P_13_3\n"
+                + "        from :new_;\n" + "        \n" + "\n" + "        \n" + "    if lv_P_13_3 != '' \n"
+                + "    and lv_idxInvoiceConf != '' \n" + "    and lv_idx != '' \n" + "    then    \n" + "        \n"
+                + "        update \"com.apotest.jpk.backend.customizing.model::custTables.P_13_3_tab\"\n"
+                + "            set \"idxInvoiceConf\" = :lv_idxInvoiceConf, \"taxCode\" = :lv_P_13_3\n"
+                + "            where \"idx\" = :lv_idx;\n" + "\n" + "    else\n" + "    \n"
+                + "        error = SELECT 400 as HTTP_STATUS_CODE,  \n" + "          'MANDT invalid' as ERROR_MESSAGE,  \n"
+                + "          'MANDT cannot be empty' as DETAIL FROM dummy;  \n" + "    \n" + "    end if;\n" + "    \n" + "END ";
+
+        System.out.println(CommonsUtils.extractArtifactNameWhenSchemaIsProvided(str)[0]);
     }
 }

--- a/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/processors/HDBSequenceDropProcessor.java
+++ b/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/processors/HDBSequenceDropProcessor.java
@@ -10,6 +10,11 @@
  */
 package com.codbex.kronos.engine.hdb.processors;
 
+import com.codbex.kronos.engine.hdb.domain.HDBSequence;
+import com.codbex.kronos.engine.hdb.parser.Constants;
+import com.codbex.kronos.engine.hdb.parser.HDBUtils;
+import com.codbex.kronos.utils.CommonsConstants;
+import com.codbex.kronos.utils.CommonsUtils;
 import java.sql.Connection;
 import java.sql.SQLException;
 import org.eclipse.dirigible.database.sql.DatabaseArtifactTypes;
@@ -18,11 +23,6 @@ import org.eclipse.dirigible.database.sql.SqlFactory;
 import org.eclipse.dirigible.database.sql.dialects.hana.HanaSqlDialect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.codbex.kronos.engine.hdb.domain.HDBSequence;
-import com.codbex.kronos.engine.hdb.parser.Constants;
-import com.codbex.kronos.engine.hdb.parser.HDBUtils;
-import com.codbex.kronos.utils.CommonsConstants;
-import com.codbex.kronos.utils.CommonsUtils;
 
 /**
  * The Class HDBSequenceDropProcessor.
@@ -45,7 +45,7 @@ public class HDBSequenceDropProcessor extends AbstractHDBProcessor<HDBSequence> 
         logger.info("Processing Drop Sequence: " + hdbSequenceName);
 
         if (SqlFactory.getNative(connection)
-                      .exists(connection, hdbSequenceName, DatabaseArtifactTypes.SEQUENCE)) {
+                      .exists(connection, sequenceModel.getSchema(), sequenceModel.getName(), DatabaseArtifactTypes.SEQUENCE)) {
             String sql = null;
             if (sequenceModel.isClassic()) {
                 sql = getDatabaseSpecificSQL(connection, hdbSequenceName);

--- a/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/processors/HDBSynonymCreateProcessor.java
+++ b/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/processors/HDBSynonymCreateProcessor.java
@@ -10,6 +10,11 @@
  */
 package com.codbex.kronos.engine.hdb.processors;
 
+import com.codbex.kronos.engine.hdb.domain.HDBSynonym;
+import com.codbex.kronos.engine.hdb.domain.HDBSynonymGroup;
+import com.codbex.kronos.engine.hdb.parser.HDBUtils;
+import com.codbex.kronos.utils.CommonsConstants;
+import com.codbex.kronos.utils.CommonsUtils;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Map;
@@ -17,11 +22,6 @@ import org.eclipse.dirigible.database.sql.DatabaseArtifactTypes;
 import org.eclipse.dirigible.database.sql.SqlFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.codbex.kronos.engine.hdb.domain.HDBSynonym;
-import com.codbex.kronos.engine.hdb.domain.HDBSynonymGroup;
-import com.codbex.kronos.engine.hdb.parser.HDBUtils;
-import com.codbex.kronos.utils.CommonsConstants;
-import com.codbex.kronos.utils.CommonsUtils;
 
 /**
  * The Class HDBSynonymCreateProcessor.
@@ -105,14 +105,13 @@ public class HDBSynonymCreateProcessor extends AbstractHDBProcessor<HDBSynonymGr
                     }
                 }
             } catch (SQLException e) {
-                if (e.getErrorCode() != DUPLICATE_SYNONYM_NAME_ERROR_CODE) {
+                if (e.getErrorCode() == DUPLICATE_SYNONYM_NAME_ERROR_CODE) {
+                    logger.info("Synonym [{}] already exists during the create process and will NOT be created", synonymName);
+                } else {
                     String errorMessage = String.format("Create synonym [%s] skipped due to an error: %s", synonymName, e.getMessage());
                     CommonsUtils.logProcessorErrors(errorMessage, CommonsConstants.PROCESSOR_ERROR, synonymModel.getLocation(),
                             CommonsConstants.HDB_SYNONYM_PARSER);
                     throw e;
-                }
-                if (logger.isWarnEnabled()) {
-                    logger.warn(String.format("Synonym [%s] already exists during the create process", synonymName));
                 }
             }
         }

--- a/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/processors/HDBTableCreateProcessor.java
+++ b/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/processors/HDBTableCreateProcessor.java
@@ -10,6 +10,11 @@
  */
 package com.codbex.kronos.engine.hdb.processors;
 
+import com.codbex.kronos.engine.hdb.domain.HDBTable;
+import com.codbex.kronos.engine.hdb.parser.Constants;
+import com.codbex.kronos.engine.hdb.parser.HDBUtils;
+import com.codbex.kronos.utils.CommonsConstants;
+import com.codbex.kronos.utils.CommonsUtils;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -20,11 +25,6 @@ import org.eclipse.dirigible.database.sql.SqlFactory;
 import org.eclipse.dirigible.database.sql.TableStatements;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.codbex.kronos.engine.hdb.domain.HDBTable;
-import com.codbex.kronos.engine.hdb.parser.Constants;
-import com.codbex.kronos.engine.hdb.parser.HDBUtils;
-import com.codbex.kronos.utils.CommonsConstants;
-import com.codbex.kronos.utils.CommonsUtils;
 
 /**
  * The HDBTableCreateProcessor.
@@ -103,11 +103,11 @@ public class HDBTableCreateProcessor extends AbstractHDBProcessor<HDBTable> {
             String message = String.format("Create table [%s] successfully", tableModel.getName());
             logger.info(message);
         } catch (SQLException ex) {
-            String errorMessage = String.format("Create table [%s] failed due to an error. Used SQL - create table %s, indices %s",
+            String errorMessage = String.format("Create table [%s] failed due to an error. Used SQL - create table [%s], indices [%s]",
                     tableModel, tableCreateStatement, String.join("; ", indicesStatements), ex);
             CommonsUtils.logProcessorErrors(errorMessage, CommonsConstants.PROCESSOR_ERROR, tableModel.getLocation(),
                     CommonsConstants.HDB_TABLE_PARSER);
-            throw ex;
+            throw new SQLException(errorMessage, ex);
         }
     }
 

--- a/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/processors/HDBTableTypeCreateProcessor.java
+++ b/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/processors/HDBTableTypeCreateProcessor.java
@@ -11,6 +11,12 @@
 package com.codbex.kronos.engine.hdb.processors;
 
 import static java.text.MessageFormat.format;
+
+import com.codbex.kronos.engine.hdb.domain.HDBTableType;
+import com.codbex.kronos.engine.hdb.domain.HDBTableTypeColumn;
+import com.codbex.kronos.engine.hdb.parser.HDBUtils;
+import com.codbex.kronos.utils.CommonsConstants;
+import com.codbex.kronos.utils.CommonsUtils;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
@@ -22,11 +28,6 @@ import org.eclipse.dirigible.database.sql.builders.tableType.CreateTableTypeBuil
 import org.eclipse.dirigible.database.sql.dialects.hana.HanaSqlDialect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.codbex.kronos.engine.hdb.domain.HDBTableType;
-import com.codbex.kronos.engine.hdb.domain.HDBTableTypeColumn;
-import com.codbex.kronos.engine.hdb.parser.HDBUtils;
-import com.codbex.kronos.utils.CommonsConstants;
-import com.codbex.kronos.utils.CommonsUtils;
 
 /**
  * The Class HDBTableTypeCreateProcessor.
@@ -95,9 +96,12 @@ public class HDBTableTypeCreateProcessor extends AbstractHDBProcessor<HDBTableTy
         }
 
         // Create public synonym only if the table type exist
+        String schema = tableTypeModel.getSchema();
+        String table = tableTypeNameWithoutSchema;
         if (SqlFactory.getNative(connection)
-                      .exists(connection, tableTypeModel.getSchema(), tableTypeNameWithoutSchema, DatabaseArtifactTypes.TABLE_TYPE)) {
-            HDBUtils.createPublicSynonymForArtifact(tableTypeNameWithoutSchema, tableTypeModel.getSchema(), connection);
+                      .exists(connection, schema, tableTypeNameWithoutSchema, DatabaseArtifactTypes.TABLE_TYPE)) {
+
+            HDBUtils.createPublicSynonymForArtifact(table, schema, connection);
         }
     }
 

--- a/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/processors/HDBViewCreateProcessor.java
+++ b/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/processors/HDBViewCreateProcessor.java
@@ -10,6 +10,11 @@
  */
 package com.codbex.kronos.engine.hdb.processors;
 
+import com.codbex.kronos.engine.hdb.domain.HDBView;
+import com.codbex.kronos.engine.hdb.parser.Constants;
+import com.codbex.kronos.engine.hdb.parser.HDBUtils;
+import com.codbex.kronos.utils.CommonsConstants;
+import com.codbex.kronos.utils.CommonsUtils;
 import java.sql.Connection;
 import java.sql.SQLException;
 import org.eclipse.dirigible.database.sql.DatabaseArtifactTypes;
@@ -18,11 +23,6 @@ import org.eclipse.dirigible.database.sql.SqlFactory;
 import org.eclipse.dirigible.database.sql.dialects.hana.HanaSqlDialect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.codbex.kronos.engine.hdb.domain.HDBView;
-import com.codbex.kronos.engine.hdb.parser.Constants;
-import com.codbex.kronos.engine.hdb.parser.HDBUtils;
-import com.codbex.kronos.utils.CommonsConstants;
-import com.codbex.kronos.utils.CommonsUtils;
 
 /**
  * The HDBViewCreateProcessor.
@@ -41,14 +41,13 @@ public class HDBViewCreateProcessor extends AbstractHDBProcessor<HDBView> {
      */
     @Override
     public void execute(Connection connection, HDBView viewModel) throws SQLException {
-        logger.info("Processing Create View: " + viewModel.getName());
-
-        String viewNameWithSchema = HDBUtils.escapeArtifactName(viewModel.getName(), viewModel.getSchema());
+        logger.info("Processing Create View: [{}]", viewModel.getName());
 
         if (!SqlFactory.getNative(connection)
-                       .exists(connection, viewNameWithSchema, DatabaseArtifactTypes.VIEW)) {
-            String sql = null;
+                       .exists(connection, viewModel.getName(), DatabaseArtifactTypes.VIEW)) {
+            String sql;
             if (viewModel.isClassic()) {
+                String viewNameWithSchema = HDBUtils.escapeArtifactName(viewModel.getName(), viewModel.getSchema());
                 sql = SqlFactory.getNative(connection)
                                 .create()
                                 .view(viewNameWithSchema)
@@ -82,7 +81,7 @@ public class HDBViewCreateProcessor extends AbstractHDBProcessor<HDBView> {
         }
 
         if (SqlFactory.getNative(connection)
-                      .exists(connection, viewNameWithSchema, DatabaseArtifactTypes.VIEW)) {
+                      .exists(connection, viewModel.getName(), DatabaseArtifactTypes.VIEW)) {
             HDBUtils.createPublicSynonymForArtifact(viewModel.getName(), viewModel.getSchema(), connection);
         }
     }

--- a/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/processors/HDBViewDropProcessor.java
+++ b/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/processors/HDBViewDropProcessor.java
@@ -10,16 +10,16 @@
  */
 package com.codbex.kronos.engine.hdb.processors;
 
+import com.codbex.kronos.engine.hdb.domain.HDBView;
+import com.codbex.kronos.engine.hdb.parser.HDBUtils;
+import com.codbex.kronos.utils.CommonsConstants;
+import com.codbex.kronos.utils.CommonsUtils;
 import java.sql.Connection;
 import java.sql.SQLException;
 import org.eclipse.dirigible.database.sql.DatabaseArtifactTypes;
 import org.eclipse.dirigible.database.sql.SqlFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.codbex.kronos.engine.hdb.domain.HDBView;
-import com.codbex.kronos.engine.hdb.parser.HDBUtils;
-import com.codbex.kronos.utils.CommonsConstants;
-import com.codbex.kronos.utils.CommonsUtils;
 
 /**
  * The HDBViewDropProcessor.
@@ -38,15 +38,15 @@ public class HDBViewDropProcessor extends AbstractHDBProcessor<HDBView> {
      */
     @Override
     public void execute(Connection connection, HDBView viewModel) throws SQLException {
-        logger.info("Processing Drop View: " + viewModel.getName());
-        String viewNameWithSchema = HDBUtils.escapeArtifactName(viewModel.getName(), viewModel.getSchema());
+        logger.info("Processing Drop View: [{}]", viewModel.getName());
 
         // Drop public synonym
         HDBUtils.dropPublicSynonymForArtifact(viewModel.getName(), viewModel.getSchema(), connection);
 
         // Drop view
         if (SqlFactory.getNative(connection)
-                      .exists(connection, viewNameWithSchema, DatabaseArtifactTypes.VIEW)) {
+                      .exists(connection, viewModel.getSchema(), viewModel.getName(), DatabaseArtifactTypes.VIEW)) {
+            String viewNameWithSchema = HDBUtils.escapeArtifactName(viewModel.getName(), viewModel.getSchema());
             String sql = SqlFactory.getNative(connection)
                                    .drop()
                                    .view(viewNameWithSchema)

--- a/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/synchronizer/HDBProceduresSynchronizer.java
+++ b/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/synchronizer/HDBProceduresSynchronizer.java
@@ -10,6 +10,7 @@
  */
 package com.codbex.kronos.engine.hdb.synchronizer;
 
+import com.codbex.kronos.commons.StringUtils;
 import com.codbex.kronos.engine.hdb.api.DataStructuresException;
 import com.codbex.kronos.engine.hdb.domain.HDBProcedure;
 import com.codbex.kronos.engine.hdb.parser.HDBDataStructureModelFactory;
@@ -131,15 +132,7 @@ public class HDBProceduresSynchronizer extends BaseSynchronizer<HDBProcedure, Lo
         try {
             procedure = HDBDataStructureModelFactory.parseProcedure(location, content);
         } catch (DataStructuresException | ArtifactParserException | IOException e) {
-            if (logger.isErrorEnabled()) {
-                logger.error(e.getMessage(), e);
-            }
-            if (logger.isErrorEnabled()) {
-                logger.error("hdbtable: {}", location);
-            }
-            if (logger.isErrorEnabled()) {
-                logger.error("content: {}", new String(content));
-            }
+            logger.error("Failed to parse [{}]. Content [{}]", location, StringUtils.toString(content), e);
             throw new ParseException(e.getMessage(), 0);
         }
 
@@ -155,15 +148,7 @@ public class HDBProceduresSynchronizer extends BaseSynchronizer<HDBProcedure, Lo
             }
             getService().save(procedure);
         } catch (Exception e) {
-            if (logger.isErrorEnabled()) {
-                logger.error(e.getMessage(), e);
-            }
-            if (logger.isErrorEnabled()) {
-                logger.error("procedure: {}", procedure);
-            }
-            if (logger.isErrorEnabled()) {
-                logger.error("content: {}", new String(content));
-            }
+            logger.error("Failed to parse [{}]. Content [{}]", location, StringUtils.toString(content), e);
             throw new ParseException(e.getMessage(), 0);
         }
         return List.of(procedure);
@@ -311,7 +296,7 @@ public class HDBProceduresSynchronizer extends BaseSynchronizer<HDBProcedure, Lo
             logger.info("Processing Update Procedure: " + procedureModel.getName());
         }
         if (SqlFactory.getNative(connection)
-                      .exists(connection, procedureModel.getName(), DatabaseArtifactTypes.PROCEDURE)) {
+                      .exists(connection, procedureModel.getSchema(), procedureModel.getName(), DatabaseArtifactTypes.PROCEDURE)) {
             executeProcedureDrop(connection, procedureModel);
             executeProcedureCreate(connection, procedureModel);
         } else {

--- a/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/synchronizer/HDBScalarFunctionsSynchronizer.java
+++ b/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/synchronizer/HDBScalarFunctionsSynchronizer.java
@@ -10,6 +10,7 @@
  */
 package com.codbex.kronos.engine.hdb.synchronizer;
 
+import com.codbex.kronos.commons.StringUtils;
 import com.codbex.kronos.engine.hdb.api.DataStructuresException;
 import com.codbex.kronos.engine.hdb.domain.HDBScalarFunction;
 import com.codbex.kronos.engine.hdb.parser.HDBDataStructureModelFactory;
@@ -131,15 +132,7 @@ public class HDBScalarFunctionsSynchronizer extends BaseSynchronizer<HDBScalarFu
         try {
             scalarfunction = HDBDataStructureModelFactory.parseScalarFunction(location, content);
         } catch (DataStructuresException | ArtifactParserException | IOException e) {
-            if (logger.isErrorEnabled()) {
-                logger.error(e.getMessage(), e);
-            }
-            if (logger.isErrorEnabled()) {
-                logger.error("hdbscalar: {}", location);
-            }
-            if (logger.isErrorEnabled()) {
-                logger.error("content: {}", new String(content));
-            }
+            logger.error("Failed to parse [{}]. Content [{}]", location, StringUtils.toString(content), e);
             throw new ParseException(e.getMessage(), 0);
         }
 
@@ -155,15 +148,7 @@ public class HDBScalarFunctionsSynchronizer extends BaseSynchronizer<HDBScalarFu
             }
             getService().save(scalarfunction);
         } catch (Exception e) {
-            if (logger.isErrorEnabled()) {
-                logger.error(e.getMessage(), e);
-            }
-            if (logger.isErrorEnabled()) {
-                logger.error("scalarfunction: {}", scalarfunction);
-            }
-            if (logger.isErrorEnabled()) {
-                logger.error("content: {}", new String(content));
-            }
+            logger.error("Failed to parse [{}]. Content [{}]", location, StringUtils.toString(content), e);
             throw new ParseException(e.getMessage(), 0);
         }
         return List.of(scalarfunction);
@@ -311,7 +296,7 @@ public class HDBScalarFunctionsSynchronizer extends BaseSynchronizer<HDBScalarFu
             logger.info("Processing Update ScalarFunction: " + scalarfunctionModel.getName());
         }
         if (SqlFactory.getNative(connection)
-                      .exists(connection, scalarfunctionModel.getName(), DatabaseArtifactTypes.FUNCTION)) {
+                      .exists(connection, scalarfunctionModel.getSchema(), scalarfunctionModel.getName(), DatabaseArtifactTypes.FUNCTION)) {
             executeScalarFunctionDrop(connection, scalarfunctionModel);
             executeScalarFunctionCreate(connection, scalarfunctionModel);
         } else {

--- a/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/synchronizer/HDBSchemaSynchronizer.java
+++ b/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/synchronizer/HDBSchemaSynchronizer.java
@@ -10,6 +10,7 @@
  */
 package com.codbex.kronos.engine.hdb.synchronizer;
 
+import com.codbex.kronos.commons.StringUtils;
 import com.codbex.kronos.engine.hdb.api.DataStructuresException;
 import com.codbex.kronos.engine.hdb.domain.HDBSchema;
 import com.codbex.kronos.engine.hdb.parser.HDBDataStructureModelFactory;
@@ -131,15 +132,7 @@ public class HDBSchemaSynchronizer extends BaseSynchronizer<HDBSchema, Long> {
         try {
             schema = HDBDataStructureModelFactory.parseSchema(location, content);
         } catch (DataStructuresException | IOException | ArtifactParserException e) {
-            if (logger.isErrorEnabled()) {
-                logger.error(e.getMessage(), e);
-            }
-            if (logger.isErrorEnabled()) {
-                logger.error("hdbtable: {}", location);
-            }
-            if (logger.isErrorEnabled()) {
-                logger.error("content: {}", new String(content));
-            }
+            logger.error("Failed to parse [{}]. Content [{}]", location, StringUtils.toString(content), e);
             throw new ParseException(e.getMessage(), 0);
         }
 
@@ -155,15 +148,7 @@ public class HDBSchemaSynchronizer extends BaseSynchronizer<HDBSchema, Long> {
             }
             getService().save(schema);
         } catch (Exception e) {
-            if (logger.isErrorEnabled()) {
-                logger.error(e.getMessage(), e);
-            }
-            if (logger.isErrorEnabled()) {
-                logger.error("schema: {}", schema);
-            }
-            if (logger.isErrorEnabled()) {
-                logger.error("content: {}", new String(content));
-            }
+            logger.error("Failed to parse [{}]. Content [{}]", location, StringUtils.toString(content), e);
             throw new ParseException(e.getMessage(), 0);
         }
         return List.of(schema);
@@ -310,7 +295,7 @@ public class HDBSchemaSynchronizer extends BaseSynchronizer<HDBSchema, Long> {
             logger.info("Processing Update Schema: " + schemaModel.getName());
         }
         if (SqlFactory.getNative(connection)
-                      .exists(connection, schemaModel.getName(), DatabaseArtifactTypes.SCHEMA)) {
+                      .exists(connection, schemaModel.getSchema(), schemaModel.getName(), DatabaseArtifactTypes.SCHEMA)) {
             executeSchemaDrop(connection, schemaModel);
             executeSchemaCreate(connection, schemaModel);
         } else {

--- a/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/synchronizer/HDBSynonymGroupsSynchronizer.java
+++ b/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/synchronizer/HDBSynonymGroupsSynchronizer.java
@@ -10,6 +10,7 @@
  */
 package com.codbex.kronos.engine.hdb.synchronizer;
 
+import com.codbex.kronos.commons.StringUtils;
 import com.codbex.kronos.engine.hdb.api.DataStructuresException;
 import com.codbex.kronos.engine.hdb.domain.HDBSynonym;
 import com.codbex.kronos.engine.hdb.domain.HDBSynonymGroup;
@@ -132,15 +133,7 @@ public class HDBSynonymGroupsSynchronizer extends BaseSynchronizer<HDBSynonymGro
         try {
             synonymGroup = HDBDataStructureModelFactory.parseSynonym(location, content);
         } catch (DataStructuresException | IOException e) {
-            if (logger.isErrorEnabled()) {
-                logger.error(e.getMessage(), e);
-            }
-            if (logger.isErrorEnabled()) {
-                logger.error("hdbtable: {}", location);
-            }
-            if (logger.isErrorEnabled()) {
-                logger.error("content: {}", new String(content));
-            }
+            logger.error("Failed to parse [{}]. Content [{}]", location, StringUtils.toString(content), e);
             throw new ParseException(e.getMessage(), 0);
         }
 
@@ -159,15 +152,7 @@ public class HDBSynonymGroupsSynchronizer extends BaseSynchronizer<HDBSynonymGro
             }
             getService().save(synonymGroup);
         } catch (Exception e) {
-            if (logger.isErrorEnabled()) {
-                logger.error(e.getMessage(), e);
-            }
-            if (logger.isErrorEnabled()) {
-                logger.error("synonym: {}", synonymGroup);
-            }
-            if (logger.isErrorEnabled()) {
-                logger.error("content: {}", new String(content));
-            }
+            logger.error("Failed to parse [{}]. Content [{}]", location, StringUtils.toString(content), e);
             throw new ParseException(e.getMessage(), 0);
         }
         return List.of(synonymGroup);
@@ -355,7 +340,7 @@ public class HDBSynonymGroupsSynchronizer extends BaseSynchronizer<HDBSynonymGro
             logger.info("Processing Update Synonym: " + synonymGroupModel.getName());
         }
         if (SqlFactory.getNative(connection)
-                      .exists(connection, synonymGroupModel.getName(), DatabaseArtifactTypes.SYNONYM)) {
+                      .exists(connection, synonymGroupModel.getSchema(), synonymGroupModel.getName(), DatabaseArtifactTypes.SYNONYM)) {
             executeSynonymGroupDrop(connection, synonymGroupModel);
             executeSynonymGroupCreate(connection, synonymGroupModel);
         } else {

--- a/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/synchronizer/HDBTableFunctionsSynchronizer.java
+++ b/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/synchronizer/HDBTableFunctionsSynchronizer.java
@@ -10,6 +10,7 @@
  */
 package com.codbex.kronos.engine.hdb.synchronizer;
 
+import com.codbex.kronos.commons.StringUtils;
 import com.codbex.kronos.engine.hdb.api.DataStructuresException;
 import com.codbex.kronos.engine.hdb.domain.HDBTableFunction;
 import com.codbex.kronos.engine.hdb.parser.HDBDataStructureModelFactory;
@@ -131,15 +132,7 @@ public class HDBTableFunctionsSynchronizer extends BaseSynchronizer<HDBTableFunc
         try {
             tablefunction = HDBDataStructureModelFactory.parseTableFunction(location, content);
         } catch (DataStructuresException | ArtifactParserException | IOException e) {
-            if (logger.isErrorEnabled()) {
-                logger.error(e.getMessage(), e);
-            }
-            if (logger.isErrorEnabled()) {
-                logger.error("hdbtable: {}", location);
-            }
-            if (logger.isErrorEnabled()) {
-                logger.error("content: {}", new String(content));
-            }
+            logger.error("Failed to parse [{}]. Content [{}]", location, StringUtils.toString(content), e);
             throw new ParseException(e.getMessage(), 0);
         }
 
@@ -155,15 +148,7 @@ public class HDBTableFunctionsSynchronizer extends BaseSynchronizer<HDBTableFunc
             }
             getService().save(tablefunction);
         } catch (Exception e) {
-            if (logger.isErrorEnabled()) {
-                logger.error(e.getMessage(), e);
-            }
-            if (logger.isErrorEnabled()) {
-                logger.error("tablefunction: {}", tablefunction);
-            }
-            if (logger.isErrorEnabled()) {
-                logger.error("content: {}", new String(content));
-            }
+            logger.error("Failed to parse [{}]. Content [{}]", location, StringUtils.toString(content), e);
             throw new ParseException(e.getMessage(), 0);
         }
         return List.of(tablefunction);
@@ -311,7 +296,7 @@ public class HDBTableFunctionsSynchronizer extends BaseSynchronizer<HDBTableFunc
             logger.info("Processing Update TableFunction: " + tablefunctionModel.getName());
         }
         if (SqlFactory.getNative(connection)
-                      .exists(connection, tablefunctionModel.getName(), DatabaseArtifactTypes.FUNCTION)) {
+                      .exists(connection, tablefunctionModel.getSchema(), tablefunctionModel.getName(), DatabaseArtifactTypes.FUNCTION)) {
             executeTableFunctionDrop(connection, tablefunctionModel);
             executeTableFunctionCreate(connection, tablefunctionModel);
         } else {

--- a/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/synchronizer/HDBTableTypesSynchronizer.java
+++ b/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/synchronizer/HDBTableTypesSynchronizer.java
@@ -10,6 +10,7 @@
  */
 package com.codbex.kronos.engine.hdb.synchronizer;
 
+import com.codbex.kronos.commons.StringUtils;
 import com.codbex.kronos.engine.hdb.api.DataStructuresException;
 import com.codbex.kronos.engine.hdb.domain.HDBTable;
 import com.codbex.kronos.engine.hdb.domain.HDBTableType;
@@ -133,15 +134,7 @@ public class HDBTableTypesSynchronizer extends BaseSynchronizer<HDBTableType, Lo
         try {
             tableType = HDBDataStructureModelFactory.parseTableType(location, content);
         } catch (DataStructuresException | IOException | ArtifactParserException e) {
-            if (logger.isErrorEnabled()) {
-                logger.error(e.getMessage(), e);
-            }
-            if (logger.isErrorEnabled()) {
-                logger.error("hdbtabletype: {}", location);
-            }
-            if (logger.isErrorEnabled()) {
-                logger.error("content: {}", new String(content));
-            }
+            logger.error("Failed to parse [{}]. Content [{}]", location, StringUtils.toString(content), e);
             throw new ParseException(e.getMessage(), 0);
         }
         // Configuration.configureObject(tableType);
@@ -159,15 +152,7 @@ public class HDBTableTypesSynchronizer extends BaseSynchronizer<HDBTableType, Lo
             getService().save(tableType);
             return List.of(tableType);
         } catch (Exception e) {
-            if (logger.isErrorEnabled()) {
-                logger.error(e.getMessage(), e);
-            }
-            if (logger.isErrorEnabled()) {
-                logger.error("hdbtabletype: {}", tableType);
-            }
-            if (logger.isErrorEnabled()) {
-                logger.error("content: {}", new String(content));
-            }
+            logger.error("Failed to parse [{}]. Content [{}]", location, StringUtils.toString(content), e);
             throw new ParseException(e.getMessage(), 0);
         }
     }
@@ -381,7 +366,7 @@ public class HDBTableTypesSynchronizer extends BaseSynchronizer<HDBTableType, Lo
             logger.info("Processing Update HDBTableType: " + tableTypeModel.getName());
         }
         if (SqlFactory.getNative(connection)
-                      .exists(connection, tableTypeModel.getName(), DatabaseArtifactTypes.TABLE_TYPE)) {
+                      .exists(connection, tableTypeModel.getSchema(), tableTypeModel.getName(), DatabaseArtifactTypes.TABLE_TYPE)) {
             // if (SqlFactory.getNative(connection).count(connection, tableTypeModel.getName()) == 0) {
             // executeTableTypeDrop(connection, tableTypeModel);
             // executeTableTypeCreate(connection, tableTypeModel);

--- a/components/engine-hdb/src/test/java/com/codbex/kronos/engine/hdb/parser/hdbview/HDBViewProcessorTest.java
+++ b/components/engine-hdb/src/test/java/com/codbex/kronos/engine/hdb/parser/hdbview/HDBViewProcessorTest.java
@@ -16,9 +16,14 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.codbex.kronos.engine.hdb.domain.HDBView;
+import com.codbex.kronos.engine.hdb.parser.Constants;
+import com.codbex.kronos.engine.hdb.parser.HDBDataStructureModelFactory;
+import com.codbex.kronos.engine.hdb.processors.HDBViewCreateProcessor;
+import com.codbex.kronos.engine.hdb.processors.HDBViewDropProcessor;
+import jakarta.transaction.Transactional;
 import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
-
 import org.apache.commons.io.IOUtils;
 import org.eclipse.dirigible.commons.config.Configuration;
 import org.eclipse.dirigible.components.api.platform.ProblemsFacade;
@@ -45,14 +50,6 @@ import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.ComponentScan;
-
-import com.codbex.kronos.engine.hdb.domain.HDBView;
-import com.codbex.kronos.engine.hdb.parser.Constants;
-import com.codbex.kronos.engine.hdb.parser.HDBDataStructureModelFactory;
-import com.codbex.kronos.engine.hdb.processors.HDBViewCreateProcessor;
-import com.codbex.kronos.engine.hdb.processors.HDBViewDropProcessor;
-
-import jakarta.transaction.Transactional;
 
 /**
  * The Class HDBViewProcessorTest.
@@ -241,7 +238,7 @@ public class HDBViewProcessorTest {
             sqlFactory.when(() -> SqlFactory.deriveDialect(mockConnection))
                       .thenReturn(new HanaSqlDialect());
             sqlFactory.when(() -> SqlFactory.getNative(mockConnection)
-                                            .exists(mockConnection, "MYSCHEMA.hdb_view::ItemsByOrderHANAv1", DatabaseArtifactTypes.VIEW))
+                                            .exists(mockConnection, "MYSCHEMA", "hdb_view::ItemsByOrderHANAv1", DatabaseArtifactTypes.VIEW))
                       .thenReturn(true);
             sqlFactory.when(() -> SqlFactory.getNative(mockConnection)
                                             .drop())

--- a/components/engine-hdi/src/main/java/com/codbex/kronos/engine/hdi/synchronizer/HDISynchronizer.java
+++ b/components/engine-hdi/src/main/java/com/codbex/kronos/engine/hdi/synchronizer/HDISynchronizer.java
@@ -10,6 +10,7 @@
  */
 package com.codbex.kronos.engine.hdi.synchronizer;
 
+import com.codbex.kronos.commons.StringUtils;
 import com.codbex.kronos.engine.hdb.api.DataStructuresException;
 import com.codbex.kronos.engine.hdb.parser.HDBParameters;
 import com.codbex.kronos.engine.hdi.domain.HDI;
@@ -151,15 +152,7 @@ public class HDISynchronizer extends BaseSynchronizer<HDI, Long> {
             }
             hdi = getService().save(hdi);
         } catch (Exception e) {
-            if (logger.isErrorEnabled()) {
-                logger.error(e.getMessage(), e);
-            }
-            if (logger.isErrorEnabled()) {
-                logger.error("hdi: {}", hdi);
-            }
-            if (logger.isErrorEnabled()) {
-                logger.error("content: {}", new String(content));
-            }
+            logger.error("Failed to parse [{}]. Content [{}]", location, StringUtils.toString(content), e);
             throw new ParseException(e.getMessage(), 0);
         }
         return List.of(hdi);

--- a/components/engine-xsjob/pom.xml
+++ b/components/engine-xsjob/pom.xml
@@ -15,7 +15,10 @@
   <packaging>jar</packaging>
 
   <dependencies>
-
+    <dependency>
+      <groupId>com.codbex.kronos</groupId>
+      <artifactId>codbex-kronos-commons</artifactId>
+    </dependency>
     <dependency>
       <groupId>com.codbex.kronos</groupId>
       <artifactId>codbex-kronos-components-engine-commons</artifactId>

--- a/components/engine-xsjob/src/main/java/com/codbex/kronos/engine/xsjob/synchronizer/XSJobSynchronizer.java
+++ b/components/engine-xsjob/src/main/java/com/codbex/kronos/engine/xsjob/synchronizer/XSJobSynchronizer.java
@@ -10,6 +10,7 @@
  */
 package com.codbex.kronos.engine.xsjob.synchronizer;
 
+import com.codbex.kronos.commons.StringUtils;
 import com.codbex.kronos.engine.xsjob.domain.XSJob;
 import com.codbex.kronos.engine.xsjob.service.XSJobService;
 import com.codbex.kronos.xsjob.ds.model.JobArtifact;
@@ -142,15 +143,7 @@ public class XSJobSynchronizer extends BaseSynchronizer<XSJob, Long> {
                 }
                 xsjob = getService().save(xsjob);
             } catch (Exception e) {
-                if (logger.isErrorEnabled()) {
-                    logger.error(e.getMessage(), e);
-                }
-                if (logger.isErrorEnabled()) {
-                    logger.error("xsjob: {}", xsjob);
-                }
-                if (logger.isErrorEnabled()) {
-                    logger.error("content: {}", new String(content));
-                }
+                logger.error("Failed to parse [{}]. Content [{}]", location, StringUtils.toString(content), e);
                 throw new ParseException(e.getMessage(), 0);
             }
         }

--- a/components/engine-xsjs/pom.xml
+++ b/components/engine-xsjs/pom.xml
@@ -15,7 +15,10 @@
   <packaging>jar</packaging>
 
   <dependencies>
-
+    <dependency>
+      <groupId>com.codbex.kronos</groupId>
+      <artifactId>codbex-kronos-commons</artifactId>
+    </dependency>
     <!-- Base -->
     <dependency>
       <groupId>org.eclipse.dirigible</groupId>

--- a/components/engine-xsjs/src/main/java/com/codbex/kronos/engine/xsjs/synchronizer/XsjslibSynchronizer.java
+++ b/components/engine-xsjs/src/main/java/com/codbex/kronos/engine/xsjs/synchronizer/XsjslibSynchronizer.java
@@ -10,6 +10,7 @@
  */
 package com.codbex.kronos.engine.xsjs.synchronizer;
 
+import com.codbex.kronos.commons.StringUtils;
 import com.codbex.kronos.engine.xsjs.domain.Xsjslib;
 import com.codbex.kronos.engine.xsjs.service.XsjslibService;
 import java.nio.file.Path;
@@ -163,15 +164,7 @@ public class XsjslibSynchronizer extends BaseSynchronizer<Xsjslib, Long> {
             }
             xsjslib = getService().save(xsjslib);
         } catch (Exception e) {
-            if (logger.isErrorEnabled()) {
-                logger.error(e.getMessage(), e);
-            }
-            if (logger.isErrorEnabled()) {
-                logger.error("xsjslib: {}", xsjslib);
-            }
-            if (logger.isErrorEnabled()) {
-                logger.error("content: {}", new String(content));
-            }
+            logger.error("Failed to parse [{}]. Content [{}]", location, StringUtils.toString(content), e);
             throw new ParseException(e.getMessage(), 0);
         }
         return List.of(xsjslib);

--- a/components/engine-xsodata/pom.xml
+++ b/components/engine-xsodata/pom.xml
@@ -17,6 +17,10 @@
   <dependencies>
     <dependency>
       <groupId>com.codbex.kronos</groupId>
+      <artifactId>codbex-kronos-commons</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.codbex.kronos</groupId>
       <artifactId>codbex-kronos-modules-parsers-xsodata</artifactId>
     </dependency>
     <dependency>

--- a/components/engine-xsodata/src/main/java/com/codbex/kronos/engine/xsodata/synchronizer/XSODataSynchronizer.java
+++ b/components/engine-xsodata/src/main/java/com/codbex/kronos/engine/xsodata/synchronizer/XSODataSynchronizer.java
@@ -10,6 +10,7 @@
  */
 package com.codbex.kronos.engine.xsodata.synchronizer;
 
+import com.codbex.kronos.commons.StringUtils;
 import com.codbex.kronos.engine.xsodata.domain.XSOData;
 import com.codbex.kronos.engine.xsodata.service.XSODataService;
 import com.codbex.kronos.engine.xsodata.transformers.TableMetadataProvider;
@@ -20,7 +21,6 @@ import com.codbex.kronos.engine.xsodata.transformers.XSODataArtefactParser;
 import com.codbex.kronos.engine.xsodata.utils.ODataUtils;
 import com.codbex.kronos.exceptions.ArtifactParserException;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.sql.SQLException;
@@ -152,7 +152,7 @@ public class XSODataSynchronizer extends BaseSynchronizer<XSOData, Long> {
     public List<XSOData> parse(String location, byte[] content) throws ParseException {
         try {
             XSOData xsodata = new XSOData();
-            xsodata = parseOData(location, new String(content, StandardCharsets.UTF_8), xsodata);
+            xsodata = parseOData(location, StringUtils.toString(content), xsodata);
             XSOData maybe = getService().findByKey(xsodata.getKey());
             if (maybe != null) {
                 xsodata.setId(maybe.getId());
@@ -160,9 +160,7 @@ public class XSODataSynchronizer extends BaseSynchronizer<XSOData, Long> {
             getService().save(xsodata);
             return List.of(xsodata);
         } catch (Exception e) {
-            logger.error(e.getMessage(), e);
-            logger.error("odata: {}", location);
-            logger.error("content: {}", new String(content));
+            logger.error("Failed to parse [{}]. Content [{}]", location, StringUtils.toString(content), e);
             throw new ParseException(e.getMessage(), 0);
         }
     }

--- a/components/engine-xsodata/src/main/java/com/codbex/kronos/engine/xsodata/transformers/TableMetadataProvider.java
+++ b/components/engine-xsodata/src/main/java/com/codbex/kronos/engine/xsodata/transformers/TableMetadataProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023 codbex or an codbex affiliate company and contributors
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at

--- a/components/engine-xsodata/src/main/java/com/codbex/kronos/engine/xsodata/transformers/TableMetadataProvider.java
+++ b/components/engine-xsodata/src/main/java/com/codbex/kronos/engine/xsodata/transformers/TableMetadataProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ * Copyright (c) 2022-2023 codbex or an codbex affiliate company and contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at

--- a/components/engine-xsodata/src/main/java/com/codbex/kronos/engine/xsodata/utils/ODataUtils.java
+++ b/components/engine-xsodata/src/main/java/com/codbex/kronos/engine/xsodata/utils/ODataUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023 codbex or an codbex affiliate company and contributors
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at

--- a/components/engine-xsodata/src/main/java/com/codbex/kronos/engine/xsodata/utils/ODataUtils.java
+++ b/components/engine-xsodata/src/main/java/com/codbex/kronos/engine/xsodata/utils/ODataUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ * Copyright (c) 2022-2023 codbex or an codbex affiliate company and contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at

--- a/components/kronos-commons/pom.xml
+++ b/components/kronos-commons/pom.xml
@@ -7,6 +7,7 @@
     <groupId>com.codbex.kronos</groupId>
     <artifactId>codbex-kronos-components-parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <name>codbex - kronos - commons</name>

--- a/components/kronos-commons/pom.xml
+++ b/components/kronos-commons/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.codbex.kronos</groupId>
+    <artifactId>codbex-kronos-components-parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <name>codbex - kronos - commons</name>
+  <artifactId>codbex-kronos-commons</artifactId>
+  <packaging>jar</packaging>
+
+</project>

--- a/components/kronos-commons/src/main/java/com/codbex/kronos/commons/StringUtils.java
+++ b/components/kronos-commons/src/main/java/com/codbex/kronos/commons/StringUtils.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package com.codbex.kronos.commons;
 
 import java.nio.charset.StandardCharsets;

--- a/components/kronos-commons/src/main/java/com/codbex/kronos/commons/StringUtils.java
+++ b/components/kronos-commons/src/main/java/com/codbex/kronos/commons/StringUtils.java
@@ -1,0 +1,12 @@
+package com.codbex.kronos.commons;
+
+import java.nio.charset.StandardCharsets;
+
+public final class StringUtils {
+
+    private StringUtils() {}
+
+    public static String toString(byte[] array) {
+        return null == array ? null : new String(array, StandardCharsets.UTF_8);
+    }
+}

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -25,6 +25,7 @@
     <module>engine-hdi</module>
     <module>engine-xsjob</module>
     <module>engine-xssecurity</module>
+    <module>kronos-commons</module>
 
 
     <!--

--- a/modules/parsers/parser-hana/src/main/java/com/codbex/kronos/parser/hana/core/HanaBaseListener.java
+++ b/modules/parsers/parser-hana/src/main/java/com/codbex/kronos/parser/hana/core/HanaBaseListener.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hana/core/Hana.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hana.core;
 

--- a/modules/parsers/parser-hana/src/main/java/com/codbex/kronos/parser/hana/core/HanaBaseVisitor.java
+++ b/modules/parsers/parser-hana/src/main/java/com/codbex/kronos/parser/hana/core/HanaBaseVisitor.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hana/core/Hana.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hana.core;
 

--- a/modules/parsers/parser-hana/src/main/java/com/codbex/kronos/parser/hana/core/HanaLexer.java
+++ b/modules/parsers/parser-hana/src/main/java/com/codbex/kronos/parser/hana/core/HanaLexer.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hana/core/Hana.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hana.core;
 

--- a/modules/parsers/parser-hana/src/main/java/com/codbex/kronos/parser/hana/core/HanaListener.java
+++ b/modules/parsers/parser-hana/src/main/java/com/codbex/kronos/parser/hana/core/HanaListener.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hana/core/Hana.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hana.core;
 

--- a/modules/parsers/parser-hana/src/main/java/com/codbex/kronos/parser/hana/core/HanaParser.java
+++ b/modules/parsers/parser-hana/src/main/java/com/codbex/kronos/parser/hana/core/HanaParser.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hana/core/Hana.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hana.core;
 

--- a/modules/parsers/parser-hana/src/main/java/com/codbex/kronos/parser/hana/core/HanaVisitor.java
+++ b/modules/parsers/parser-hana/src/main/java/com/codbex/kronos/parser/hana/core/HanaVisitor.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hana/core/Hana.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hana.core;
 

--- a/modules/parsers/parser-hdbdd/src/main/java/com/codbex/kronos/parser/hdbdd/core/CdsBaseListener.java
+++ b/modules/parsers/parser-hdbdd/src/main/java/com/codbex/kronos/parser/hdbdd/core/CdsBaseListener.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbdd/core/Cds.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbdd.core;
 

--- a/modules/parsers/parser-hdbdd/src/main/java/com/codbex/kronos/parser/hdbdd/core/CdsBaseVisitor.java
+++ b/modules/parsers/parser-hdbdd/src/main/java/com/codbex/kronos/parser/hdbdd/core/CdsBaseVisitor.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbdd/core/Cds.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbdd.core;
 

--- a/modules/parsers/parser-hdbdd/src/main/java/com/codbex/kronos/parser/hdbdd/core/CdsLexer.java
+++ b/modules/parsers/parser-hdbdd/src/main/java/com/codbex/kronos/parser/hdbdd/core/CdsLexer.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbdd/core/Cds.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbdd.core;
 

--- a/modules/parsers/parser-hdbdd/src/main/java/com/codbex/kronos/parser/hdbdd/core/CdsListener.java
+++ b/modules/parsers/parser-hdbdd/src/main/java/com/codbex/kronos/parser/hdbdd/core/CdsListener.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbdd/core/Cds.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbdd.core;
 

--- a/modules/parsers/parser-hdbdd/src/main/java/com/codbex/kronos/parser/hdbdd/core/CdsParser.java
+++ b/modules/parsers/parser-hdbdd/src/main/java/com/codbex/kronos/parser/hdbdd/core/CdsParser.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbdd/core/Cds.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbdd.core;
 

--- a/modules/parsers/parser-hdbdd/src/main/java/com/codbex/kronos/parser/hdbdd/core/CdsTokens.java
+++ b/modules/parsers/parser-hdbdd/src/main/java/com/codbex/kronos/parser/hdbdd/core/CdsTokens.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbdd/core/CdsTokens.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbdd.core;
 

--- a/modules/parsers/parser-hdbdd/src/main/java/com/codbex/kronos/parser/hdbdd/core/CdsVisitor.java
+++ b/modules/parsers/parser-hdbdd/src/main/java/com/codbex/kronos/parser/hdbdd/core/CdsVisitor.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbdd/core/Cds.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbdd.core;
 

--- a/modules/parsers/parser-hdbschema/src/main/java/com/codbex/kronos/parser/hdbschema/core/HDBSchemaBaseListener.java
+++ b/modules/parsers/parser-hdbschema/src/main/java/com/codbex/kronos/parser/hdbschema/core/HDBSchemaBaseListener.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbschema/core/HDBSchema.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbschema.core;
 

--- a/modules/parsers/parser-hdbschema/src/main/java/com/codbex/kronos/parser/hdbschema/core/HDBSchemaBaseVisitor.java
+++ b/modules/parsers/parser-hdbschema/src/main/java/com/codbex/kronos/parser/hdbschema/core/HDBSchemaBaseVisitor.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbschema/core/HDBSchema.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbschema.core;
 

--- a/modules/parsers/parser-hdbschema/src/main/java/com/codbex/kronos/parser/hdbschema/core/HDBSchemaLexer.java
+++ b/modules/parsers/parser-hdbschema/src/main/java/com/codbex/kronos/parser/hdbschema/core/HDBSchemaLexer.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbschema/core/HDBSchema.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbschema.core;
 

--- a/modules/parsers/parser-hdbschema/src/main/java/com/codbex/kronos/parser/hdbschema/core/HDBSchemaListener.java
+++ b/modules/parsers/parser-hdbschema/src/main/java/com/codbex/kronos/parser/hdbschema/core/HDBSchemaListener.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbschema/core/HDBSchema.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbschema.core;
 

--- a/modules/parsers/parser-hdbschema/src/main/java/com/codbex/kronos/parser/hdbschema/core/HDBSchemaParser.java
+++ b/modules/parsers/parser-hdbschema/src/main/java/com/codbex/kronos/parser/hdbschema/core/HDBSchemaParser.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbschema/core/HDBSchema.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbschema.core;
 

--- a/modules/parsers/parser-hdbschema/src/main/java/com/codbex/kronos/parser/hdbschema/core/HDBSchemaVisitor.java
+++ b/modules/parsers/parser-hdbschema/src/main/java/com/codbex/kronos/parser/hdbschema/core/HDBSchemaVisitor.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbschema/core/HDBSchema.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbschema.core;
 

--- a/modules/parsers/parser-hdbsequence/src/main/java/com/codbex/kronos/parser/hdbsequence/core/HDBSequenceBaseListener.java
+++ b/modules/parsers/parser-hdbsequence/src/main/java/com/codbex/kronos/parser/hdbsequence/core/HDBSequenceBaseListener.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbsequence/core/HDBSequence.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbsequence.core;
 

--- a/modules/parsers/parser-hdbsequence/src/main/java/com/codbex/kronos/parser/hdbsequence/core/HDBSequenceBaseVisitor.java
+++ b/modules/parsers/parser-hdbsequence/src/main/java/com/codbex/kronos/parser/hdbsequence/core/HDBSequenceBaseVisitor.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbsequence/core/HDBSequence.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbsequence.core;
 

--- a/modules/parsers/parser-hdbsequence/src/main/java/com/codbex/kronos/parser/hdbsequence/core/HDBSequenceLexer.java
+++ b/modules/parsers/parser-hdbsequence/src/main/java/com/codbex/kronos/parser/hdbsequence/core/HDBSequenceLexer.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbsequence/core/HDBSequence.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbsequence.core;
 

--- a/modules/parsers/parser-hdbsequence/src/main/java/com/codbex/kronos/parser/hdbsequence/core/HDBSequenceListener.java
+++ b/modules/parsers/parser-hdbsequence/src/main/java/com/codbex/kronos/parser/hdbsequence/core/HDBSequenceListener.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbsequence/core/HDBSequence.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbsequence.core;
 

--- a/modules/parsers/parser-hdbsequence/src/main/java/com/codbex/kronos/parser/hdbsequence/core/HDBSequenceParser.java
+++ b/modules/parsers/parser-hdbsequence/src/main/java/com/codbex/kronos/parser/hdbsequence/core/HDBSequenceParser.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbsequence/core/HDBSequence.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbsequence.core;
 

--- a/modules/parsers/parser-hdbsequence/src/main/java/com/codbex/kronos/parser/hdbsequence/core/HDBSequenceVisitor.java
+++ b/modules/parsers/parser-hdbsequence/src/main/java/com/codbex/kronos/parser/hdbsequence/core/HDBSequenceVisitor.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbsequence/core/HDBSequence.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbsequence.core;
 

--- a/modules/parsers/parser-hdbtable/src/main/java/com/codbex/kronos/parser/hdbtable/core/HDBTableBaseListener.java
+++ b/modules/parsers/parser-hdbtable/src/main/java/com/codbex/kronos/parser/hdbtable/core/HDBTableBaseListener.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbtable/core/HDBTable.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbtable.core;
 

--- a/modules/parsers/parser-hdbtable/src/main/java/com/codbex/kronos/parser/hdbtable/core/HDBTableBaseVisitor.java
+++ b/modules/parsers/parser-hdbtable/src/main/java/com/codbex/kronos/parser/hdbtable/core/HDBTableBaseVisitor.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbtable/core/HDBTable.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbtable.core;
 

--- a/modules/parsers/parser-hdbtable/src/main/java/com/codbex/kronos/parser/hdbtable/core/HDBTableLexer.java
+++ b/modules/parsers/parser-hdbtable/src/main/java/com/codbex/kronos/parser/hdbtable/core/HDBTableLexer.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbtable/core/HDBTable.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbtable.core;
 

--- a/modules/parsers/parser-hdbtable/src/main/java/com/codbex/kronos/parser/hdbtable/core/HDBTableListener.java
+++ b/modules/parsers/parser-hdbtable/src/main/java/com/codbex/kronos/parser/hdbtable/core/HDBTableListener.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbtable/core/HDBTable.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbtable.core;
 

--- a/modules/parsers/parser-hdbtable/src/main/java/com/codbex/kronos/parser/hdbtable/core/HDBTableParser.java
+++ b/modules/parsers/parser-hdbtable/src/main/java/com/codbex/kronos/parser/hdbtable/core/HDBTableParser.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbtable/core/HDBTable.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbtable.core;
 

--- a/modules/parsers/parser-hdbtable/src/main/java/com/codbex/kronos/parser/hdbtable/core/HDBTableVisitor.java
+++ b/modules/parsers/parser-hdbtable/src/main/java/com/codbex/kronos/parser/hdbtable/core/HDBTableVisitor.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbtable/core/HDBTable.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbtable.core;
 

--- a/modules/parsers/parser-hdbti/src/main/java/com/codbex/kronos/parser/hdbti/core/HDBTIBaseListener.java
+++ b/modules/parsers/parser-hdbti/src/main/java/com/codbex/kronos/parser/hdbti/core/HDBTIBaseListener.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbti/core/HDBTI.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbti.core;
 

--- a/modules/parsers/parser-hdbti/src/main/java/com/codbex/kronos/parser/hdbti/core/HDBTIBaseVisitor.java
+++ b/modules/parsers/parser-hdbti/src/main/java/com/codbex/kronos/parser/hdbti/core/HDBTIBaseVisitor.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbti/core/HDBTI.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbti.core;
 

--- a/modules/parsers/parser-hdbti/src/main/java/com/codbex/kronos/parser/hdbti/core/HDBTILexer.java
+++ b/modules/parsers/parser-hdbti/src/main/java/com/codbex/kronos/parser/hdbti/core/HDBTILexer.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbti/core/HDBTI.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbti.core;
 

--- a/modules/parsers/parser-hdbti/src/main/java/com/codbex/kronos/parser/hdbti/core/HDBTIListener.java
+++ b/modules/parsers/parser-hdbti/src/main/java/com/codbex/kronos/parser/hdbti/core/HDBTIListener.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbti/core/HDBTI.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbti.core;
 

--- a/modules/parsers/parser-hdbti/src/main/java/com/codbex/kronos/parser/hdbti/core/HDBTIParser.java
+++ b/modules/parsers/parser-hdbti/src/main/java/com/codbex/kronos/parser/hdbti/core/HDBTIParser.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbti/core/HDBTI.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbti.core;
 

--- a/modules/parsers/parser-hdbti/src/main/java/com/codbex/kronos/parser/hdbti/core/HDBTIVisitor.java
+++ b/modules/parsers/parser-hdbti/src/main/java/com/codbex/kronos/parser/hdbti/core/HDBTIVisitor.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbti/core/HDBTI.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbti.core;
 

--- a/modules/parsers/parser-hdbview/src/main/java/com/codbex/kronos/parser/hdbview/core/HDBViewBaseListener.java
+++ b/modules/parsers/parser-hdbview/src/main/java/com/codbex/kronos/parser/hdbview/core/HDBViewBaseListener.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbview/core/HDBView.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbview.core;
 

--- a/modules/parsers/parser-hdbview/src/main/java/com/codbex/kronos/parser/hdbview/core/HDBViewBaseVisitor.java
+++ b/modules/parsers/parser-hdbview/src/main/java/com/codbex/kronos/parser/hdbview/core/HDBViewBaseVisitor.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbview/core/HDBView.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbview.core;
 

--- a/modules/parsers/parser-hdbview/src/main/java/com/codbex/kronos/parser/hdbview/core/HDBViewLexer.java
+++ b/modules/parsers/parser-hdbview/src/main/java/com/codbex/kronos/parser/hdbview/core/HDBViewLexer.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbview/core/HDBView.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbview.core;
 

--- a/modules/parsers/parser-hdbview/src/main/java/com/codbex/kronos/parser/hdbview/core/HDBViewListener.java
+++ b/modules/parsers/parser-hdbview/src/main/java/com/codbex/kronos/parser/hdbview/core/HDBViewListener.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbview/core/HDBView.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbview.core;
 

--- a/modules/parsers/parser-hdbview/src/main/java/com/codbex/kronos/parser/hdbview/core/HDBViewParser.java
+++ b/modules/parsers/parser-hdbview/src/main/java/com/codbex/kronos/parser/hdbview/core/HDBViewParser.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbview/core/HDBView.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbview.core;
 

--- a/modules/parsers/parser-hdbview/src/main/java/com/codbex/kronos/parser/hdbview/core/HDBViewVisitor.java
+++ b/modules/parsers/parser-hdbview/src/main/java/com/codbex/kronos/parser/hdbview/core/HDBViewVisitor.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbview/core/HDBView.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbview.core;
 

--- a/modules/parsers/parser-xsodata/src/main/java/com/codbex/kronos/parser/xsodata/core/XSODataBaseListener.java
+++ b/modules/parsers/parser-xsodata/src/main/java/com/codbex/kronos/parser/xsodata/core/XSODataBaseListener.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/xsodata/core/XSOData.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.xsodata.core;
 

--- a/modules/parsers/parser-xsodata/src/main/java/com/codbex/kronos/parser/xsodata/core/XSODataBaseVisitor.java
+++ b/modules/parsers/parser-xsodata/src/main/java/com/codbex/kronos/parser/xsodata/core/XSODataBaseVisitor.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/xsodata/core/XSOData.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.xsodata.core;
 

--- a/modules/parsers/parser-xsodata/src/main/java/com/codbex/kronos/parser/xsodata/core/XSODataLexer.java
+++ b/modules/parsers/parser-xsodata/src/main/java/com/codbex/kronos/parser/xsodata/core/XSODataLexer.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/xsodata/core/XSOData.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.xsodata.core;
 

--- a/modules/parsers/parser-xsodata/src/main/java/com/codbex/kronos/parser/xsodata/core/XSODataListener.java
+++ b/modules/parsers/parser-xsodata/src/main/java/com/codbex/kronos/parser/xsodata/core/XSODataListener.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/xsodata/core/XSOData.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.xsodata.core;
 

--- a/modules/parsers/parser-xsodata/src/main/java/com/codbex/kronos/parser/xsodata/core/XSODataParser.java
+++ b/modules/parsers/parser-xsodata/src/main/java/com/codbex/kronos/parser/xsodata/core/XSODataParser.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/xsodata/core/XSOData.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.xsodata.core;
 

--- a/modules/parsers/parser-xsodata/src/main/java/com/codbex/kronos/parser/xsodata/core/XSODataVisitor.java
+++ b/modules/parsers/parser-xsodata/src/main/java/com/codbex/kronos/parser/xsodata/core/XSODataVisitor.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/xsodata/core/XSOData.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.xsodata.core;
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.codbex.platform</groupId>
     <artifactId>codbex-platform-parent</artifactId>
-    <version>1.0.5</version>
+    <version>1.0.6</version>
   </parent>
 
   <name>codbex - kronos - parent</name>
@@ -389,6 +389,11 @@
       <dependency>
         <groupId>com.codbex.kronos</groupId>
         <artifactId>codbex-kronos-components-template-xsjs-import</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.codbex.kronos</groupId>
+        <artifactId>codbex-kronos-commons</artifactId>
         <version>${project.version}</version>
       </dependency>
     </dependencies>


### PR DESCRIPTION
Do not fail when artifacts like views, tables, synonyms, etc. exist.
A fix for https://github.com/codbex/codbex-kronos/issues/586