### PR TITLE
Fix tables update, sequence drop with restrict, toStrings and others

### DIFF
--- a/application/src/main/resources/logback.xml
+++ b/application/src/main/resources/logback.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration packagingData="true">
+  <conversionRule conversionWord="tenant" converterClass="org.eclipse.dirigible.components.base.logging.TenantConverter"/>
 
   <!--
     Try to set LOGS_DIR for the file appenders to the environment variables
@@ -19,28 +20,28 @@
   <!-- Send messages to System.out -->
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%-5level] [%thread{8}] %logger{36} - %msg%n</pattern>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%-5level] [%thread{8}] [%tenant] %logger{36} - %msg%n</pattern>
     </encoder>
   </appender>
 
   <appender name="FILE_CORE" class="ch.qos.logback.core.FileAppender">
     <file>${LOGS_DIR}/dirigible-core-${date}.log</file>
     <encoder>
-      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
+      <pattern>%date %level [%thread] [%tenant] %logger{10} [%file:%line] %msg%n</pattern>
     </encoder>
   </appender>
 
   <appender name="FILE_APPS" class="ch.qos.logback.core.FileAppender">
     <file>${LOGS_DIR}/dirigible-apps-${date}.log</file>
     <encoder>
-      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
+      <pattern>%date %level [%thread] [%tenant] %logger{10} [%file:%line] %msg%n</pattern>
     </encoder>
   </appender>
 
   <appender name="FILE_BASE" class="ch.qos.logback.core.FileAppender">
     <file>${LOGS_DIR}/dirigible-base-${date}.log</file>
     <encoder>
-      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
+      <pattern>%date %level [%thread] [%tenant] %logger{10} [%file:%line] %msg%n</pattern>
     </encoder>
   </appender>
 
@@ -57,13 +58,6 @@
     <appender-ref ref="ConsoleLoggingAppender"/>
   </logger>
 
-
-  <logger name="org.eclipse.dirigible.api.v3.core.Console" level="INFO" additivity="false">
-    <appender-ref ref="STDOUT"/>
-    <appender-ref ref="FILE_CORE"/>
-    <appender-ref ref="ConsoleLoggingAppender"/>
-  </logger>
-
   <logger name="app" level="INFO" additivity="false">
     <appender-ref ref="STDOUT"/>
     <appender-ref ref="FILE_APPS"/>
@@ -73,10 +67,13 @@
   <root level="INFO">
     <appender-ref ref="STDOUT"/>
     <appender-ref ref="FILE_BASE"/>
+    <appender-ref ref="ConsoleLoggingAppender"/>
   </root>
 
   <logger name="org.eclipse.dirigible.components.initializers.synchronizer" level="INFO"/>
+  <logger name="org.eclipse.dirigible.components.base.synchronizer" level="INFO"/>
+  <logger name="org.eclipse.dirigible.components.tenants.tenant" level="INFO"/>
 
-  <logger name="com.codbex.kronos.engine.hdb" level="ALL"/>
+  <logger name="com.codbex.kronos.engine.hdb" level="INFO"/>
 
 </configuration>

--- a/components/engine-hdb/pom.xml
+++ b/components/engine-hdb/pom.xml
@@ -137,6 +137,11 @@
       <artifactId>h2</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/domain/HDBTableColumn.java
+++ b/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/domain/HDBTableColumn.java
@@ -10,6 +10,8 @@
  */
 package com.codbex.kronos.engine.hdb.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.gson.annotations.Expose;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -19,12 +21,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.google.gson.annotations.Expose;
 
 /**
  * The Class TableColumn.
@@ -137,19 +135,8 @@ public class HDBTableColumn extends HDBColumn {
         this.table = table;
     }
 
-    /**
-     * To string.
-     *
-     * @return the string
-     */
     @Override
     public String toString() {
-        return "HDBTableColumn [id=" + id + ", getName()=" + getName() + ", getType()=" + getType() + ", getLength()=" + getLength()
-                + ", isNullable()=" + isNullable() + ", isPrimaryKey()=" + isPrimaryKey() + ", getDefaultValue()=" + getDefaultValue()
-                + ", getPrecision()=" + getPrecision() + ", getScale()=" + getScale() + ", isUnique()=" + isUnique()
-                + ", isDefaultValueDateTimeFunction()=" + isDefaultValueDateTimeFunction() + ", getComment()=" + getComment()
-                + ", getAlias()=" + getAlias() + ", isFuzzySearchIndex()=" + isFuzzySearchIndex() + ", getStatement()=" + getStatement()
-                + ", isCalculatedColumn()=" + isCalculatedColumn() + "]";
+        return "HDBTableColumn{" + "id=" + id + ", table=" + (table == null ? null : table.getName()) + '}';
     }
-
 }

--- a/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/domain/HDBTableConstraintCheck.java
+++ b/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/domain/HDBTableConstraintCheck.java
@@ -10,21 +10,13 @@
  */
 package com.codbex.kronos.engine.hdb.domain;
 
+import com.google.gson.annotations.Expose;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.google.gson.annotations.Expose;
 
 /**
  * The Class TableConstraintCheck.
@@ -104,17 +96,8 @@ public class HDBTableConstraintCheck extends HDBTableConstraint {
         this.expression = expression;
     }
 
-    /**
-     * To string.
-     *
-     * @return the string
-     */
     @Override
     public String toString() {
-        return "TableConstraintCheck [id=" + id + ", expression=" + expression + ", name=" + name + ", modifiers=" + modifiers
-                + ", columns=" + columns + ", constraints.table=" + constraints.getTable()
-                                                                               .getName()
-                + "]";
+        return "HDBTableConstraintCheck{" + "id=" + id + ", expression='" + expression + '\'' + '}';
     }
-
 }

--- a/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/domain/HDBTableConstraintForeignKey.java
+++ b/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/domain/HDBTableConstraintForeignKey.java
@@ -10,6 +10,7 @@
  */
 package com.codbex.kronos.engine.hdb.domain;
 
+import com.google.gson.annotations.Expose;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
@@ -17,10 +18,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-
+import java.util.Arrays;
 import org.eclipse.dirigible.components.base.converters.ArrayOfStringsToCsvConverter;
-
-import com.google.gson.annotations.Expose;
 
 /**
  * The Class TableConstraintForeignKey.
@@ -169,17 +168,9 @@ public class HDBTableConstraintForeignKey extends HDBTableConstraint {
         this.referencedColumns = referencedColumns;
     }
 
-    /**
-     * To string.
-     *
-     * @return the string
-     */
     @Override
     public String toString() {
-        return "TableConstraintForeignKey [id=" + id + ", referencedTable=" + referencedTable + ", referencedColumns=" + referencedColumns
-                + ", name=" + name + ", modifiers=" + modifiers + ", columns=" + columns + ", constraints.table=" + constraints.getTable()
-                                                                                                                               .getName()
-                + "]";
+        return "HDBTableConstraintForeignKey{" + "id=" + id + ", referencedTable='" + referencedTable + '\'' + ", referencedSchema='"
+                + referencedSchema + '\'' + ", referencedColumns=" + Arrays.toString(referencedColumns) + '}';
     }
-
 }

--- a/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/domain/HDBTableConstraintPrimaryKey.java
+++ b/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/domain/HDBTableConstraintPrimaryKey.java
@@ -69,17 +69,8 @@ public class HDBTableConstraintPrimaryKey extends HDBTableConstraint {
         this.id = id;
     }
 
-    /**
-     * To string.
-     *
-     * @return the string
-     */
     @Override
     public String toString() {
-        return "TableConstraintPrimaryKey [id=" + id + ", name=" + name + ", modifiers=" + modifiers + ", columns=" + columns
-                + ", constraints.table=" + constraints.getTable()
-                                                      .getName()
-                + "]";
+        return "HDBTableConstraintPrimaryKey{" + "id=" + id + '}';
     }
-
 }

--- a/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/domain/HDBTableConstraintUnique.java
+++ b/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/domain/HDBTableConstraintUnique.java
@@ -10,14 +10,13 @@
  */
 package com.codbex.kronos.engine.hdb.domain;
 
+import com.google.gson.annotations.Expose;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-
-import com.google.gson.annotations.Expose;
 
 /**
  * The Class TableConstraintUnique.
@@ -124,17 +123,8 @@ public class HDBTableConstraintUnique extends HDBTableConstraint {
         this.order = order;
     }
 
-    /**
-     * To string.
-     *
-     * @return the string
-     */
     @Override
     public String toString() {
-        return "TableConstraintUnique [id=" + id + ", indexType=" + indexType + ", order=" + order + ", name=" + name + ", modifiers="
-                + modifiers + ", columns=" + columns + ", constraints.table=" + constraints.getTable()
-                                                                                           .getName()
-                + "]";
+        return "HDBTableConstraintUnique{" + "id=" + id + ", indexType='" + indexType + '\'' + ", order='" + order + '\'' + '}';
     }
-
 }

--- a/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/domain/HDBTableConstraints.java
+++ b/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/domain/HDBTableConstraints.java
@@ -10,10 +10,8 @@
  */
 package com.codbex.kronos.engine.hdb.domain;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.gson.annotations.Expose;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -26,14 +24,12 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
-
+import java.util.ArrayList;
+import java.util.List;
 import org.hibernate.annotations.LazyCollection;
 import org.hibernate.annotations.LazyCollectionOption;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.google.gson.annotations.Expose;
 
 /**
  * The Class TableConstraints.
@@ -261,17 +257,9 @@ public class HDBTableConstraints {
         this.table = table;
     }
 
-    /**
-     * To string.
-     *
-     * @return the string
-     */
     @Override
     public String toString() {
-        return "TableConstraints [id=" + id + ", primaryKey=" + primaryKey + ", foreignKeys="
-                + (foreignKeys != null ? Objects.toString(foreignKeys) : "null") + ", uniqueIndexes="
-                + (uniqueIndexes != null ? Objects.toString(uniqueIndexes) : "null") + ", checks="
-                + (checks != null ? Objects.toString(checks) : "null") + ", table=" + table.getName() + "]";
+        return "HDBTableConstraints{" + "id=" + id + ", primaryKey=" + primaryKey + ", foreignKeys=" + foreignKeys + ", uniqueIndexes="
+                + uniqueIndexes + ", checks=" + checks + ", table=" + (table == null ? null : table.getName()) + '}';
     }
-
 }

--- a/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/domain/HDBTableIndex.java
+++ b/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/domain/HDBTableIndex.java
@@ -10,6 +10,8 @@
  */
 package com.codbex.kronos.engine.hdb.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.gson.annotations.Expose;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
@@ -19,13 +21,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-
+import java.util.Arrays;
 import org.eclipse.dirigible.components.base.converters.ArrayOfStringsToCsvConverter;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.google.gson.annotations.Expose;
 
 /**
  * The Class TableIndex.
@@ -229,15 +228,9 @@ public class HDBTableIndex {
         this.table = table;
     }
 
-    /**
-     * To string.
-     *
-     * @return the string
-     */
     @Override
     public String toString() {
-        return "TableIndex [id=" + id + ", name=" + name + ", type=" + type + ", unique=" + unique + ", order=" + order + ", columns="
-                + columns + ", table=" + table.getName() + "]";
+        return "HDBTableIndex{" + "id=" + id + ", name='" + name + '\'' + ", type='" + type + '\'' + ", unique=" + unique + ", order='"
+                + order + '\'' + ", columns=" + Arrays.toString(columns) + ", table=" + (table == null ? null : table.getName()) + '}';
     }
-
 }

--- a/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/parser/HDBTableDataStructureParser.java
+++ b/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/parser/HDBTableDataStructureParser.java
@@ -13,6 +13,7 @@ package com.codbex.kronos.engine.hdb.parser;
 import com.codbex.kronos.engine.hdb.api.DataStructuresException;
 import com.codbex.kronos.engine.hdb.api.IDataStructureModel;
 import com.codbex.kronos.engine.hdb.domain.HDBTable;
+import com.codbex.kronos.engine.hdb.domain.HDBTableColumn;
 import com.codbex.kronos.engine.hdb.domain.HDBTableConstraintPrimaryKey;
 import com.codbex.kronos.engine.hdb.domain.HDBTableConstraintUnique;
 import com.codbex.kronos.engine.hdb.domain.HDBTableConstraints;
@@ -114,7 +115,7 @@ public class HDBTableDataStructureParser implements HDBDataStructureParser<HDBTa
      * @throws ArtifactParserException the artifact parser exception
      */
     private HDBTable parseHanaXSClassicContent(String location, String content) throws IOException, ArtifactParserException {
-        logger.debug("Parsing hdbtable as Hana XS Classic format");
+        logger.debug("Parsing hdbtable [{}] as Hana XS Classic format. Content: [{}]", location, content);
         ByteArrayInputStream is = new ByteArrayInputStream(content.getBytes());
         ANTLRInputStream inputStream = new ANTLRInputStream(is);
         HDBTableLexer hdbTableLexer = new HDBTableLexer(inputStream);
@@ -254,9 +255,20 @@ public class HDBTableDataStructureParser implements HDBDataStructureParser<HDBTa
      * @return the data structure HDB table model
      */
     private HDBTable parseHanaXSAdvancedContent(String location, String content) {
-        logger.debug("Parsing hdbtable as Hana XS Advanced format");
+        logger.debug("Parsing hdbtable [{}] as Hana XS Advanced format. Content: [{}]", location, content);
         HDBTable dataStructureHDBTableModel = new HDBTable();
         HDBUtils.populateDataStructureModel(location, content, dataStructureHDBTableModel, IDataStructureModel.TYPE_HDB_TABLE, false);
+
+        List<HDBTableColumn> columns = HDBUtils.extractColumns(content)
+                                               .stream()
+                                               .map(column -> {
+                                                   column.setTable(dataStructureHDBTableModel);
+                                                   return column;
+                                               })
+                                               .toList();
+
+        dataStructureHDBTableModel.setColumns(columns);
+
         dataStructureHDBTableModel.setContent(content);
 
         Optional<String> schema = extractSchema(content);

--- a/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/parser/HDBUtils.java
+++ b/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/parser/HDBUtils.java
@@ -135,8 +135,8 @@ public class HDBUtils {
     public static List<HDBTableColumn> extractColumns(String content) {
         Matcher tableContentSourceMatcher = TABLE_CONTENT_SOURCE_PATTERN.matcher(content);
         if (!tableContentSourceMatcher.find()) {
-            throw new IllegalArgumentException(
-                    "Invalid content [" + content + "]. It doesn't match the pattern " + TABLE_CONTENT_SOURCE_PATTERN);
+            throw new IllegalArgumentException("Invalid content [" + content + "]. It doesn't match the pattern ["
+                    + TABLE_CONTENT_SOURCE_PATTERN + "]. Most probably this is invalid content.");
         }
         Pattern columnNamePattern = Pattern.compile(COLUMN_NAME_REGEX, Pattern.CASE_INSENSITIVE);
         Matcher columnNameMatcher = columnNamePattern.matcher(tableContentSourceMatcher.group(1));

--- a/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/parser/HDBUtils.java
+++ b/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/parser/HDBUtils.java
@@ -56,6 +56,12 @@ public class HDBUtils {
      */
     private static final String commentRegex = "(/\\*[^*]*\\*+(?:[^/*][^*]*\\*+)*/)|(--.*)";
 
+    private static final String SQL_TYPES =
+            "ARRAY|DATE|SECONDDATE|TIMESTAMP|TIME|TINYINT|SMALLINT|INTEGER|INT|BIGINT|SMALLDECIMAL|REAL|DOUBLE|TEXT|BINTEXT|VARCHAR|NVARCHAR|ALPHANUM|SHORTTEXT|VARBINARY|DECIMAL|FLOAT|BOOLEAN";
+    private static final String COLUMN_NAME_REGEX = "\"?(\\w+)\"?\\s+(" + SQL_TYPES + ")";
+    private static final Pattern COLUMN_NAME_PATTERN = Pattern.compile(COLUMN_NAME_REGEX, Pattern.CASE_INSENSITIVE);
+
+    private static final Pattern TABLE_CONTENT_SOURCE_PATTERN = Pattern.compile("\\((.*)\\)", Pattern.DOTALL);
     /**
      * The Constant ESCAPE_SYMBOL.
      */
@@ -127,16 +133,12 @@ public class HDBUtils {
     }
 
     public static List<HDBTableColumn> extractColumns(String content) {
-        Pattern tableContentSourcePattern = Pattern.compile("\\((.*)\\)", Pattern.DOTALL);
-        Matcher tableContentSourceMatcher = tableContentSourcePattern.matcher(content);
+        Matcher tableContentSourceMatcher = TABLE_CONTENT_SOURCE_PATTERN.matcher(content);
         if (!tableContentSourceMatcher.find()) {
             throw new IllegalArgumentException(
-                    "Invalid content [" + content + "]. It doesn't match the pattern " + tableContentSourcePattern);
+                    "Invalid content [" + content + "]. It doesn't match the pattern " + TABLE_CONTENT_SOURCE_PATTERN);
         }
-        String sqlTypes =
-                "ARRAY|DATE|SECONDDATE|TIMESTAMP|TIME|TINYINT|SMALLINT|INTEGER|INT|BIGINT|SMALLDECIMAL|REAL|DOUBLE|TEXT|BINTEXT|VARCHAR|NVARCHAR|ALPHANUM|SHORTTEXT|VARBINARY|DECIMAL|FLOAT|BOOLEAN";
-        String columnNameRegex = "\"?(\\w+)\"?\\s+(" + sqlTypes + ")";
-        Pattern columnNamePattern = Pattern.compile(columnNameRegex, Pattern.CASE_INSENSITIVE);
+        Pattern columnNamePattern = Pattern.compile(COLUMN_NAME_REGEX, Pattern.CASE_INSENSITIVE);
         Matcher columnNameMatcher = columnNamePattern.matcher(tableContentSourceMatcher.group(1));
 
         return columnNameMatcher.results()

--- a/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/parser/HDBUtils.java
+++ b/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/parser/HDBUtils.java
@@ -22,6 +22,7 @@ import com.codbex.kronos.engine.hdb.domain.HDBDataStructure;
 import com.codbex.kronos.engine.hdb.domain.HDBSynonym;
 import com.codbex.kronos.engine.hdb.domain.HDBSynonymGroup;
 import com.codbex.kronos.engine.hdb.domain.HDBSynonymTarget;
+import com.codbex.kronos.engine.hdb.domain.HDBTableColumn;
 import com.codbex.kronos.engine.hdb.processors.HDBSynonymCreateProcessor;
 import com.codbex.kronos.engine.hdb.processors.HDBSynonymDropProcessor;
 import com.codbex.kronos.exceptions.ArtifactParserException;
@@ -34,6 +35,10 @@ import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -119,6 +124,29 @@ public class HDBUtils {
         model.setCreatedBy(UserFacade.getName());
         model.setCreatedAt(new Timestamp(new java.util.Date().getTime()));
         model.setClassic(classic);
+    }
+
+    public static List<HDBTableColumn> extractColumns(String content) {
+        Pattern tableContentSourcePattern = Pattern.compile("\\((.*)\\)", Pattern.DOTALL);
+        Matcher tableContentSourceMatcher = tableContentSourcePattern.matcher(content);
+        if (!tableContentSourceMatcher.find()) {
+            throw new IllegalArgumentException(
+                    "Invalid content [" + content + "]. It doesn't match the pattern " + tableContentSourcePattern);
+        }
+        String sqlTypes =
+                "ARRAY|DATE|SECONDDATE|TIMESTAMP|TIME|TINYINT|SMALLINT|INTEGER|INT|BIGINT|SMALLDECIMAL|REAL|DOUBLE|TEXT|BINTEXT|VARCHAR|NVARCHAR|ALPHANUM|SHORTTEXT|VARBINARY|DECIMAL|FLOAT|BOOLEAN";
+        String columnNameRegex = "\"?(\\w+)\"?\\s+(" + sqlTypes + ")";
+        Pattern columnNamePattern = Pattern.compile(columnNameRegex, Pattern.CASE_INSENSITIVE);
+        Matcher columnNameMatcher = columnNamePattern.matcher(tableContentSourceMatcher.group(1));
+
+        return columnNameMatcher.results()
+                                .map(matchResult -> {
+                                    HDBTableColumn column = new HDBTableColumn();
+                                    column.setName(matchResult.group(1));
+                                    column.setType(matchResult.group(2));
+                                    return column;
+                                })
+                                .collect(Collectors.toList());
     }
 
     /**

--- a/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/processors/HDBTableCreateProcessor.java
+++ b/components/engine-hdb/src/main/java/com/codbex/kronos/engine/hdb/processors/HDBTableCreateProcessor.java
@@ -44,7 +44,7 @@ public class HDBTableCreateProcessor extends AbstractHDBProcessor<HDBTable> {
      */
     @Override
     public void execute(Connection connection, HDBTable tableModel) throws SQLException {
-        logger.info("Processing Create Table: " + tableModel.getName());
+        logger.info("Processing Create Table [{}] in schema [{}]", tableModel.getName(), tableModel.getSchema());
 
         Collection<String> indicesStatements = new ArrayList<>();
         String tableCreateStatement;
@@ -100,8 +100,7 @@ public class HDBTableCreateProcessor extends AbstractHDBProcessor<HDBTable> {
                 // Maybe comment for the moment?
                 // executeBatch(indicesStatements, connection);
             }
-            String message = String.format("Create table [%s] successfully", tableModel.getName());
-            logger.info(message);
+            logger.info("Create table [{}] in schema [{}] successfully", tableModel.getName(), tableModel.getSchema());
         } catch (SQLException ex) {
             String errorMessage = String.format("Create table [%s] failed due to an error. Used SQL - create table [%s], indices [%s]",
                     tableModel, tableCreateStatement, String.join("; ", indicesStatements), ex);

--- a/components/engine-hdb/src/test/java/com/codbex/kronos/engine/hdb/parser/HDBUtilsTest.java
+++ b/components/engine-hdb/src/test/java/com/codbex/kronos/engine/hdb/parser/HDBUtilsTest.java
@@ -1,0 +1,76 @@
+package com.codbex.kronos.engine.hdb.parser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.codbex.kronos.engine.hdb.domain.HDBTableColumn;
+import java.util.List;
+import java.util.Objects;
+import org.junit.jupiter.api.Test;
+
+class HDBUtilsTest {
+
+    @Test
+    void testExtractColumnsWithMultilineContent() {
+        String createSQL = """
+                CREATE COLUMN TABLE "MY_SCHEMA"."MY_TABLE" (\s
+                    "id" INTEGER NOT NULL,
+                    "column1" INTEGER NOT NULL,
+                    "Column2" INTEGER,
+                    column3 INTEGER,
+                    "column4" NVARCHAR(30),
+                    "column5" DECIMAL(20, 2),
+                    "column6" DECIMAL(20, 2),
+                    "column7" INTEGER,
+                    "column8" DECIMAL(20, 2),
+                    "column9" DECIMAL(20, 2),
+                    "column10" NVARCHAR(256),
+                    "cOlUmN11" NVARCHAR(256),
+                    "column12" NVARCHAR(256),
+                    PRIMARY KEY ("idx"),
+                    FOREIGN KEY ("Column2") REFERENCES "AF477A06D"."com.apotest.jpk.backend.model::jpk.Column2"("idx") ON DELETE RESTRICT,
+                    FOREIGN KEY ("column3") REFERENCES "AF477A06D"."com.apotest.jpk.backend.model::jpk.column3"("idx") ON DELETE RESTRICT
+                )
+                """;
+        testExtractColumns(createSQL);
+    }
+
+    @Test
+    void testExtractColumnsWithSingleLineContent() {
+        String createSQL =
+                "CREATE COLUMN TABLE \"MY_SCHEMA\".\"MY_TABLE\"(\"id\" INTEGER NOT NULL,\"column1\" INTEGER NOT NULL,\"Column2\" INTEGER,column3 INTEGER,\"column4\" NVARCHAR(30),\"column5\" DECIMAL(20,2),\"column6\" DECIMAL(20,2),\"column7\" INTEGER,\"column8\" DECIMAL(20,2),\"column9\" DECIMAL(20,2),\"column10\" NVARCHAR(256),\"cOlUmN11\" NVARCHAR(256),\"column12\" NVARCHAR(256),PRIMARY KEY(\"idx\"),FOREIGN KEY(\"Column2\")REFERENCES \"AF477A06D\".\"com.apotest.jpk.backend.model::jpk.Column2\"(\"idx\")ON DELETE RESTRICT,FOREIGN KEY(\"column3\")REFERENCES \"AF477A06D\".\"com.apotest.jpk.backend.model::jpk.column3\"(\"idx\")ON DELETE RESTRICT)\n";
+        testExtractColumns(createSQL);
+    }
+
+    private void testExtractColumns(String sql) {
+
+        List<HDBTableColumn> expectedColumns = List.of(//
+                createHDBTableColumn("id", "INTEGER"), createHDBTableColumn("column1", "INTEGER"),
+                createHDBTableColumn("Column2", "INTEGER"), createHDBTableColumn("column3", "INTEGER"),
+                createHDBTableColumn("column4", "NVARCHAR"), createHDBTableColumn("column5", "DECIMAL"),
+                createHDBTableColumn("column6", "DECIMAL"), createHDBTableColumn("column7", "INTEGER"),
+                createHDBTableColumn("column8", "DECIMAL"), createHDBTableColumn("column9", "DECIMAL"),
+                createHDBTableColumn("column10", "NVARCHAR"), createHDBTableColumn("cOlUmN11", "NVARCHAR"),
+                createHDBTableColumn("column12", "NVARCHAR"));
+
+        List<HDBTableColumn> extractedColumns = HDBUtils.extractColumns(sql);
+
+        assertThat(extractedColumns).hasSize(expectedColumns.size());
+        expectedColumns.forEach(expectedColumn -> assertThat(containsElement(extractedColumns, expectedColumn)).isTrue());
+    }
+
+    private boolean containsElement(List<HDBTableColumn> actualColumns, HDBTableColumn expectedColumn) {
+        return actualColumns.stream()
+                            .filter(c -> Objects.equals(expectedColumn.getName(), c.getName())
+                                    && Objects.equals(expectedColumn.getType(), c.getType()))
+                            .findFirst()
+                            .isPresent();
+    }
+
+    private HDBTableColumn createHDBTableColumn(String name, String type) {
+        HDBTableColumn column = new HDBTableColumn();
+        column.setName(name);
+        column.setType(type);
+
+        return column;
+    }
+}

--- a/components/engine-hdb/src/test/java/com/codbex/kronos/engine/hdb/parser/hdbtable/HDBTableDataStructureParserTest.java
+++ b/components/engine-hdb/src/test/java/com/codbex/kronos/engine/hdb/parser/hdbtable/HDBTableDataStructureParserTest.java
@@ -17,18 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-
-import org.apache.commons.io.IOUtils;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.ComponentScan;
-
 import com.codbex.kronos.engine.hdb.api.DataStructuresException;
 import com.codbex.kronos.engine.hdb.domain.HDBTable;
 import com.codbex.kronos.engine.hdb.domain.HDBTableColumn;
@@ -38,8 +26,17 @@ import com.codbex.kronos.engine.hdb.parser.HDBTableDataStructureParser;
 import com.codbex.kronos.exceptions.ArtifactParserException;
 import com.codbex.kronos.parser.hdbtable.exceptions.HDBTableDuplicatePropertyException;
 import com.codbex.kronos.parser.hdbtable.exceptions.HDBTableMissingPropertyException;
-
 import jakarta.transaction.Transactional;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.ComponentScan;
 
 /**
  * The Class HDBTableDataStructureParserTest.
@@ -220,7 +217,7 @@ public class HDBTableDataStructureParserTest {
      */
     @Test
     public void parseHanaXSAdvancedContentWithAdditionalSpaces() throws Exception {
-        String content = " COLUMN TABLE      KRONOS_HDI_SIMPLE_TABLE COLUMN1 INTEGER )";
+        String content = " COLUMN TABLE      KRONOS_HDI_SIMPLE_TABLE (COLUMN1 INTEGER)";
         HDBTable model = HDBDataStructureModelFactory.parseTable("/HdbtableHanaXSAdvancedContent.hdbtable", content);
         assertEquals(false, model.isClassic());
         assertEquals(content, model.getContent());

--- a/components/engine-xsodata/src/main/java/com/codbex/kronos/engine/xsodata/transformers/TableMetadataProvider.java
+++ b/components/engine-xsodata/src/main/java/com/codbex/kronos/engine/xsodata/transformers/TableMetadataProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023 codbex or an codbex affiliate company and contributors
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at

--- a/components/engine-xsodata/src/main/java/com/codbex/kronos/engine/xsodata/transformers/TableMetadataProvider.java
+++ b/components/engine-xsodata/src/main/java/com/codbex/kronos/engine/xsodata/transformers/TableMetadataProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ * Copyright (c) 2022-2023 codbex or an codbex affiliate company and contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at

--- a/components/engine-xsodata/src/main/java/com/codbex/kronos/engine/xsodata/utils/ODataUtils.java
+++ b/components/engine-xsodata/src/main/java/com/codbex/kronos/engine/xsodata/utils/ODataUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023 codbex or an codbex affiliate company and contributors
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at

--- a/components/engine-xsodata/src/main/java/com/codbex/kronos/engine/xsodata/utils/ODataUtils.java
+++ b/components/engine-xsodata/src/main/java/com/codbex/kronos/engine/xsodata/utils/ODataUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ * Copyright (c) 2022-2023 codbex or an codbex affiliate company and contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at

--- a/components/kronos-commons/pom.xml
+++ b/components/kronos-commons/pom.xml
@@ -7,6 +7,7 @@
     <groupId>com.codbex.kronos</groupId>
     <artifactId>codbex-kronos-components-parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <name>codbex - kronos - commons</name>

--- a/components/kronos-commons/pom.xml
+++ b/components/kronos-commons/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.codbex.kronos</groupId>
     <artifactId>codbex-kronos-components-parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/components/kronos-commons/pom.xml
+++ b/components/kronos-commons/pom.xml
@@ -6,8 +6,7 @@
   <parent>
     <groupId>com.codbex.kronos</groupId>
     <artifactId>codbex-kronos-components-parent</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
 
   <name>codbex - kronos - commons</name>

--- a/components/kronos-commons/src/main/java/com/codbex/kronos/commons/StringUtils.java
+++ b/components/kronos-commons/src/main/java/com/codbex/kronos/commons/StringUtils.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package com.codbex.kronos.commons;
 
 import java.nio.charset.StandardCharsets;

--- a/components/kronos-commons/src/main/java/com/codbex/kronos/commons/StringUtils.java
+++ b/components/kronos-commons/src/main/java/com/codbex/kronos/commons/StringUtils.java
@@ -1,13 +1,3 @@
-/*
- * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
- *
- * All rights reserved. This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v20.html
- *
- * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
- * SPDX-License-Identifier: EPL-2.0
- */
 package com.codbex.kronos.commons;
 
 import java.nio.charset.StandardCharsets;

--- a/modules/parsers/parser-hana/src/main/java/com/codbex/kronos/parser/hana/core/HanaBaseListener.java
+++ b/modules/parsers/parser-hana/src/main/java/com/codbex/kronos/parser/hana/core/HanaBaseListener.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hana/core/Hana.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hana.core;
 

--- a/modules/parsers/parser-hana/src/main/java/com/codbex/kronos/parser/hana/core/HanaBaseVisitor.java
+++ b/modules/parsers/parser-hana/src/main/java/com/codbex/kronos/parser/hana/core/HanaBaseVisitor.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hana/core/Hana.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hana.core;
 

--- a/modules/parsers/parser-hana/src/main/java/com/codbex/kronos/parser/hana/core/HanaLexer.java
+++ b/modules/parsers/parser-hana/src/main/java/com/codbex/kronos/parser/hana/core/HanaLexer.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hana/core/Hana.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hana.core;
 

--- a/modules/parsers/parser-hana/src/main/java/com/codbex/kronos/parser/hana/core/HanaListener.java
+++ b/modules/parsers/parser-hana/src/main/java/com/codbex/kronos/parser/hana/core/HanaListener.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hana/core/Hana.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hana.core;
 

--- a/modules/parsers/parser-hana/src/main/java/com/codbex/kronos/parser/hana/core/HanaParser.java
+++ b/modules/parsers/parser-hana/src/main/java/com/codbex/kronos/parser/hana/core/HanaParser.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hana/core/Hana.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hana.core;
 

--- a/modules/parsers/parser-hana/src/main/java/com/codbex/kronos/parser/hana/core/HanaVisitor.java
+++ b/modules/parsers/parser-hana/src/main/java/com/codbex/kronos/parser/hana/core/HanaVisitor.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hana/core/Hana.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hana.core;
 

--- a/modules/parsers/parser-hdbdd/src/main/java/com/codbex/kronos/parser/hdbdd/core/CdsBaseListener.java
+++ b/modules/parsers/parser-hdbdd/src/main/java/com/codbex/kronos/parser/hdbdd/core/CdsBaseListener.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbdd/core/Cds.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbdd.core;
 

--- a/modules/parsers/parser-hdbdd/src/main/java/com/codbex/kronos/parser/hdbdd/core/CdsBaseVisitor.java
+++ b/modules/parsers/parser-hdbdd/src/main/java/com/codbex/kronos/parser/hdbdd/core/CdsBaseVisitor.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbdd/core/Cds.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbdd.core;
 

--- a/modules/parsers/parser-hdbdd/src/main/java/com/codbex/kronos/parser/hdbdd/core/CdsLexer.java
+++ b/modules/parsers/parser-hdbdd/src/main/java/com/codbex/kronos/parser/hdbdd/core/CdsLexer.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbdd/core/Cds.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbdd.core;
 

--- a/modules/parsers/parser-hdbdd/src/main/java/com/codbex/kronos/parser/hdbdd/core/CdsListener.java
+++ b/modules/parsers/parser-hdbdd/src/main/java/com/codbex/kronos/parser/hdbdd/core/CdsListener.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbdd/core/Cds.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbdd.core;
 

--- a/modules/parsers/parser-hdbdd/src/main/java/com/codbex/kronos/parser/hdbdd/core/CdsParser.java
+++ b/modules/parsers/parser-hdbdd/src/main/java/com/codbex/kronos/parser/hdbdd/core/CdsParser.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbdd/core/Cds.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbdd.core;
 

--- a/modules/parsers/parser-hdbdd/src/main/java/com/codbex/kronos/parser/hdbdd/core/CdsTokens.java
+++ b/modules/parsers/parser-hdbdd/src/main/java/com/codbex/kronos/parser/hdbdd/core/CdsTokens.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbdd/core/CdsTokens.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbdd.core;
 

--- a/modules/parsers/parser-hdbdd/src/main/java/com/codbex/kronos/parser/hdbdd/core/CdsVisitor.java
+++ b/modules/parsers/parser-hdbdd/src/main/java/com/codbex/kronos/parser/hdbdd/core/CdsVisitor.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbdd/core/Cds.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbdd.core;
 

--- a/modules/parsers/parser-hdbschema/src/main/java/com/codbex/kronos/parser/hdbschema/core/HDBSchemaBaseListener.java
+++ b/modules/parsers/parser-hdbschema/src/main/java/com/codbex/kronos/parser/hdbschema/core/HDBSchemaBaseListener.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbschema/core/HDBSchema.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbschema.core;
 

--- a/modules/parsers/parser-hdbschema/src/main/java/com/codbex/kronos/parser/hdbschema/core/HDBSchemaBaseVisitor.java
+++ b/modules/parsers/parser-hdbschema/src/main/java/com/codbex/kronos/parser/hdbschema/core/HDBSchemaBaseVisitor.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbschema/core/HDBSchema.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbschema.core;
 

--- a/modules/parsers/parser-hdbschema/src/main/java/com/codbex/kronos/parser/hdbschema/core/HDBSchemaLexer.java
+++ b/modules/parsers/parser-hdbschema/src/main/java/com/codbex/kronos/parser/hdbschema/core/HDBSchemaLexer.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbschema/core/HDBSchema.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbschema.core;
 

--- a/modules/parsers/parser-hdbschema/src/main/java/com/codbex/kronos/parser/hdbschema/core/HDBSchemaListener.java
+++ b/modules/parsers/parser-hdbschema/src/main/java/com/codbex/kronos/parser/hdbschema/core/HDBSchemaListener.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbschema/core/HDBSchema.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbschema.core;
 

--- a/modules/parsers/parser-hdbschema/src/main/java/com/codbex/kronos/parser/hdbschema/core/HDBSchemaParser.java
+++ b/modules/parsers/parser-hdbschema/src/main/java/com/codbex/kronos/parser/hdbschema/core/HDBSchemaParser.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbschema/core/HDBSchema.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbschema.core;
 

--- a/modules/parsers/parser-hdbschema/src/main/java/com/codbex/kronos/parser/hdbschema/core/HDBSchemaVisitor.java
+++ b/modules/parsers/parser-hdbschema/src/main/java/com/codbex/kronos/parser/hdbschema/core/HDBSchemaVisitor.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbschema/core/HDBSchema.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbschema.core;
 

--- a/modules/parsers/parser-hdbsequence/src/main/java/com/codbex/kronos/parser/hdbsequence/core/HDBSequenceBaseListener.java
+++ b/modules/parsers/parser-hdbsequence/src/main/java/com/codbex/kronos/parser/hdbsequence/core/HDBSequenceBaseListener.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbsequence/core/HDBSequence.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbsequence.core;
 

--- a/modules/parsers/parser-hdbsequence/src/main/java/com/codbex/kronos/parser/hdbsequence/core/HDBSequenceBaseVisitor.java
+++ b/modules/parsers/parser-hdbsequence/src/main/java/com/codbex/kronos/parser/hdbsequence/core/HDBSequenceBaseVisitor.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbsequence/core/HDBSequence.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbsequence.core;
 

--- a/modules/parsers/parser-hdbsequence/src/main/java/com/codbex/kronos/parser/hdbsequence/core/HDBSequenceLexer.java
+++ b/modules/parsers/parser-hdbsequence/src/main/java/com/codbex/kronos/parser/hdbsequence/core/HDBSequenceLexer.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbsequence/core/HDBSequence.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbsequence.core;
 

--- a/modules/parsers/parser-hdbsequence/src/main/java/com/codbex/kronos/parser/hdbsequence/core/HDBSequenceListener.java
+++ b/modules/parsers/parser-hdbsequence/src/main/java/com/codbex/kronos/parser/hdbsequence/core/HDBSequenceListener.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbsequence/core/HDBSequence.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbsequence.core;
 

--- a/modules/parsers/parser-hdbsequence/src/main/java/com/codbex/kronos/parser/hdbsequence/core/HDBSequenceParser.java
+++ b/modules/parsers/parser-hdbsequence/src/main/java/com/codbex/kronos/parser/hdbsequence/core/HDBSequenceParser.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbsequence/core/HDBSequence.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbsequence.core;
 

--- a/modules/parsers/parser-hdbsequence/src/main/java/com/codbex/kronos/parser/hdbsequence/core/HDBSequenceVisitor.java
+++ b/modules/parsers/parser-hdbsequence/src/main/java/com/codbex/kronos/parser/hdbsequence/core/HDBSequenceVisitor.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbsequence/core/HDBSequence.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbsequence.core;
 

--- a/modules/parsers/parser-hdbtable/src/main/java/com/codbex/kronos/parser/hdbtable/core/HDBTableBaseListener.java
+++ b/modules/parsers/parser-hdbtable/src/main/java/com/codbex/kronos/parser/hdbtable/core/HDBTableBaseListener.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbtable/core/HDBTable.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbtable.core;
 

--- a/modules/parsers/parser-hdbtable/src/main/java/com/codbex/kronos/parser/hdbtable/core/HDBTableBaseVisitor.java
+++ b/modules/parsers/parser-hdbtable/src/main/java/com/codbex/kronos/parser/hdbtable/core/HDBTableBaseVisitor.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbtable/core/HDBTable.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbtable.core;
 

--- a/modules/parsers/parser-hdbtable/src/main/java/com/codbex/kronos/parser/hdbtable/core/HDBTableLexer.java
+++ b/modules/parsers/parser-hdbtable/src/main/java/com/codbex/kronos/parser/hdbtable/core/HDBTableLexer.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbtable/core/HDBTable.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbtable.core;
 

--- a/modules/parsers/parser-hdbtable/src/main/java/com/codbex/kronos/parser/hdbtable/core/HDBTableListener.java
+++ b/modules/parsers/parser-hdbtable/src/main/java/com/codbex/kronos/parser/hdbtable/core/HDBTableListener.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbtable/core/HDBTable.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbtable.core;
 

--- a/modules/parsers/parser-hdbtable/src/main/java/com/codbex/kronos/parser/hdbtable/core/HDBTableParser.java
+++ b/modules/parsers/parser-hdbtable/src/main/java/com/codbex/kronos/parser/hdbtable/core/HDBTableParser.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbtable/core/HDBTable.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbtable.core;
 

--- a/modules/parsers/parser-hdbtable/src/main/java/com/codbex/kronos/parser/hdbtable/core/HDBTableVisitor.java
+++ b/modules/parsers/parser-hdbtable/src/main/java/com/codbex/kronos/parser/hdbtable/core/HDBTableVisitor.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbtable/core/HDBTable.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbtable.core;
 

--- a/modules/parsers/parser-hdbti/src/main/java/com/codbex/kronos/parser/hdbti/core/HDBTIBaseListener.java
+++ b/modules/parsers/parser-hdbti/src/main/java/com/codbex/kronos/parser/hdbti/core/HDBTIBaseListener.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbti/core/HDBTI.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbti.core;
 

--- a/modules/parsers/parser-hdbti/src/main/java/com/codbex/kronos/parser/hdbti/core/HDBTIBaseVisitor.java
+++ b/modules/parsers/parser-hdbti/src/main/java/com/codbex/kronos/parser/hdbti/core/HDBTIBaseVisitor.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbti/core/HDBTI.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbti.core;
 

--- a/modules/parsers/parser-hdbti/src/main/java/com/codbex/kronos/parser/hdbti/core/HDBTILexer.java
+++ b/modules/parsers/parser-hdbti/src/main/java/com/codbex/kronos/parser/hdbti/core/HDBTILexer.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbti/core/HDBTI.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbti.core;
 

--- a/modules/parsers/parser-hdbti/src/main/java/com/codbex/kronos/parser/hdbti/core/HDBTIListener.java
+++ b/modules/parsers/parser-hdbti/src/main/java/com/codbex/kronos/parser/hdbti/core/HDBTIListener.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbti/core/HDBTI.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbti.core;
 

--- a/modules/parsers/parser-hdbti/src/main/java/com/codbex/kronos/parser/hdbti/core/HDBTIParser.java
+++ b/modules/parsers/parser-hdbti/src/main/java/com/codbex/kronos/parser/hdbti/core/HDBTIParser.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbti/core/HDBTI.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbti.core;
 

--- a/modules/parsers/parser-hdbti/src/main/java/com/codbex/kronos/parser/hdbti/core/HDBTIVisitor.java
+++ b/modules/parsers/parser-hdbti/src/main/java/com/codbex/kronos/parser/hdbti/core/HDBTIVisitor.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbti/core/HDBTI.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbti.core;
 

--- a/modules/parsers/parser-hdbview/src/main/java/com/codbex/kronos/parser/hdbview/core/HDBViewBaseListener.java
+++ b/modules/parsers/parser-hdbview/src/main/java/com/codbex/kronos/parser/hdbview/core/HDBViewBaseListener.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbview/core/HDBView.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbview.core;
 

--- a/modules/parsers/parser-hdbview/src/main/java/com/codbex/kronos/parser/hdbview/core/HDBViewBaseVisitor.java
+++ b/modules/parsers/parser-hdbview/src/main/java/com/codbex/kronos/parser/hdbview/core/HDBViewBaseVisitor.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbview/core/HDBView.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbview.core;
 

--- a/modules/parsers/parser-hdbview/src/main/java/com/codbex/kronos/parser/hdbview/core/HDBViewLexer.java
+++ b/modules/parsers/parser-hdbview/src/main/java/com/codbex/kronos/parser/hdbview/core/HDBViewLexer.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbview/core/HDBView.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbview.core;
 

--- a/modules/parsers/parser-hdbview/src/main/java/com/codbex/kronos/parser/hdbview/core/HDBViewListener.java
+++ b/modules/parsers/parser-hdbview/src/main/java/com/codbex/kronos/parser/hdbview/core/HDBViewListener.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbview/core/HDBView.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbview.core;
 

--- a/modules/parsers/parser-hdbview/src/main/java/com/codbex/kronos/parser/hdbview/core/HDBViewParser.java
+++ b/modules/parsers/parser-hdbview/src/main/java/com/codbex/kronos/parser/hdbview/core/HDBViewParser.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbview/core/HDBView.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbview.core;
 

--- a/modules/parsers/parser-hdbview/src/main/java/com/codbex/kronos/parser/hdbview/core/HDBViewVisitor.java
+++ b/modules/parsers/parser-hdbview/src/main/java/com/codbex/kronos/parser/hdbview/core/HDBViewVisitor.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/hdbview/core/HDBView.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.hdbview.core;
 

--- a/modules/parsers/parser-xsodata/src/main/java/com/codbex/kronos/parser/xsodata/core/XSODataBaseListener.java
+++ b/modules/parsers/parser-xsodata/src/main/java/com/codbex/kronos/parser/xsodata/core/XSODataBaseListener.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/xsodata/core/XSOData.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.xsodata.core;
 

--- a/modules/parsers/parser-xsodata/src/main/java/com/codbex/kronos/parser/xsodata/core/XSODataBaseVisitor.java
+++ b/modules/parsers/parser-xsodata/src/main/java/com/codbex/kronos/parser/xsodata/core/XSODataBaseVisitor.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/xsodata/core/XSOData.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.xsodata.core;
 

--- a/modules/parsers/parser-xsodata/src/main/java/com/codbex/kronos/parser/xsodata/core/XSODataLexer.java
+++ b/modules/parsers/parser-xsodata/src/main/java/com/codbex/kronos/parser/xsodata/core/XSODataLexer.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/xsodata/core/XSOData.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.xsodata.core;
 

--- a/modules/parsers/parser-xsodata/src/main/java/com/codbex/kronos/parser/xsodata/core/XSODataListener.java
+++ b/modules/parsers/parser-xsodata/src/main/java/com/codbex/kronos/parser/xsodata/core/XSODataListener.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/xsodata/core/XSOData.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.xsodata.core;
 

--- a/modules/parsers/parser-xsodata/src/main/java/com/codbex/kronos/parser/xsodata/core/XSODataParser.java
+++ b/modules/parsers/parser-xsodata/src/main/java/com/codbex/kronos/parser/xsodata/core/XSODataParser.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/xsodata/core/XSOData.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.xsodata.core;
 

--- a/modules/parsers/parser-xsodata/src/main/java/com/codbex/kronos/parser/xsodata/core/XSODataVisitor.java
+++ b/modules/parsers/parser-xsodata/src/main/java/com/codbex/kronos/parser/xsodata/core/XSODataVisitor.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 // Generated from com/codbex/kronos/parser/xsodata/core/XSOData.g4 by ANTLR 4.13.1
 package com.codbex.kronos.parser.xsodata.core;
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,14 +5,14 @@
   <parent>
     <groupId>com.codbex.platform</groupId>
     <artifactId>codbex-platform-parent</artifactId>
-    <version>1.0.6</version>
+    <version>1.0.9</version>
   </parent>
 
   <name>codbex - kronos - parent</name>
   <description>codbex kronos</description>
   <groupId>com.codbex.kronos</groupId>
   <artifactId>codbex-kronos-parent</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <inceptionYear>2022</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -5,14 +5,14 @@
   <parent>
     <groupId>com.codbex.platform</groupId>
     <artifactId>codbex-platform-parent</artifactId>
-    <version>1.0.8</version>
+    <version>1.0.6</version>
   </parent>
 
   <name>codbex - kronos - parent</name>
   <description>codbex kronos</description>
   <groupId>com.codbex.kronos</groupId>
   <artifactId>codbex-kronos-parent</artifactId>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <inceptionYear>2022</inceptionYear>


### PR DESCRIPTION
- Fix tables update - when HDBTable artifacts are updated, some columns are dropped 
- fix drop sequence with RESTRICT
- fix toStrings because sometimes they throw NPE
- update logback.xml


