### PR TITLE
move oras-artifacts from `/codbex` to `/opt/codbex` + update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
       * [Docker](#docker)
       * [Build](#build)
       * [Docker Build](#docker-build)
+      * [ORAS artifacts](#oras-artifacts)
       * [Run](#run)
       * [Debug](#debug)
       * [Spring profiles](#spring-profiles)
@@ -129,6 +130,23 @@ oras pull "ghcr.io/codbex/codbex-bw-migration/codbex-abap-bw:latest" -o oras-art
 
 docker buildx build \
   --platform linux/amd64,linux/arm64 . --tag "$IMAGE_TAG"
+
+```
+
+#### ORAS artifacts
+You need to pull the required ORAS artifacts locally if they are needed for your scenario.<br>
+For example if you work on BW migration scenario where ABAP transpilation is needed.<br>
+This is needed for the scenario where the Kronos is not started as a Docker container.
+```shell
+sudo su
+mkdir -p /opt/codbex
+cd /opt/codbex
+
+ORAS_GIT_TOKEN='<token_for_the_repos>'
+oras login ghcr.io -u oauth2 -p "$ORAS_GIT_TOKEN"
+
+rm -rf oras-artifacts
+oras pull "ghcr.io/codbex/codbex-bw-migration/codbex-abap-bw:latest" -o oras-artifacts
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ docker buildx build \
 ```
 
 #### ORAS artifacts
-You need to pull the required ORAS artifacts locally for the scenario where the Kronos is not started as a Docker container.<br>
+You need to pull the required ORAS artifacts locally if they are needed for your scenario and the Kronos is not started as a Docker container.<br>
 For example if you work on BW migration scenario where ABAP transpilation is needed.<br>
 ```shell
 sudo su

--- a/README.md
+++ b/README.md
@@ -134,9 +134,8 @@ docker buildx build \
 ```
 
 #### ORAS artifacts
-You need to pull the required ORAS artifacts locally if they are needed for your scenario.<br>
+You need to pull the required ORAS artifacts locally for the scenario where the Kronos is not started as a Docker container.<br>
 For example if you work on BW migration scenario where ABAP transpilation is needed.<br>
-This is needed for the scenario where the Kronos is not started as a Docker container.
 ```shell
 sudo su
 mkdir -p /opt/codbex

--- a/application/Dockerfile
+++ b/application/Dockerfile
@@ -12,8 +12,8 @@ RUN npm i -g typescript
 RUN apk add git
 RUN apk --no-cache add msttcorefonts-installer fontconfig && update-ms-fonts && fc-cache -f
 
-# Copy ORAS artifacts to the dedicated folder "/codbex"
-COPY oras-artifacts/ /codbex/oras-artifacts/
+# Copy ORAS artifacts to the dedicated folder "/opt/codbex"
+COPY oras-artifacts/ /opt/codbex/oras-artifacts/
 
 EXPOSE 80
 


### PR DESCRIPTION
This is needed to enable local run of Kronos with java -jar in unix systems.