### PR TITLE
Docker image based on ghcr.io/graalvm/jdk-community:21

### DIFF
--- a/application/Dockerfile
+++ b/application/Dockerfile
@@ -1,21 +1,35 @@
-FROM amazoncorretto:21-alpine
+FROM ghcr.io/graalvm/jdk-community:21
 
 VOLUME /tmp
 
-RUN apk update && \
-    apk add --no-cache \
-    ttyd
+# Install dependencies via microdnf (Oracle Linux minimal)
+RUN microdnf install -y \
+    nodejs \
+    # provides xargs used in ABAP transpilation scripts
+    findutils \
+    git \
+    fontconfig \
+    curl \
+    && microdnf clean all
 
-RUN apk add nodejs npm
-RUN npm i -g esbuild
-RUN npm i -g typescript
-RUN apk add git
-RUN apk --no-cache add msttcorefonts-installer fontconfig && update-ms-fonts && fc-cache -f
+# Install ttyd
+RUN curl -L https://github.com/tsl0922/ttyd/releases/download/1.7.7/ttyd.x86_64 \
+    -o /usr/local/bin/ttyd && \
+    chmod +x /usr/local/bin/ttyd
+
+RUN npm install -g esbuild typescript
 
 # Copy ORAS artifacts to the dedicated folder "/opt/codbex"
 COPY oras-artifacts/ /opt/codbex/oras-artifacts/
 
 EXPOSE 80
 
+WORKDIR /
+
 COPY target/codbex-kronos-application-*-executable.jar codbex-kronos.jar
-ENTRYPOINT ["java","--add-opens", "java.base/java.lang=ALL-UNNAMED", "--add-opens", "java.base/java.lang.reflect=ALL-UNNAMED", "--add-opens", "java.base/java.nio=ALL-UNNAMED", "-jar", "/codbex-kronos.jar"]
+
+ENTRYPOINT ["java", \
+    "--add-opens", "java.base/java.lang=ALL-UNNAMED", \
+    "--add-opens", "java.base/java.lang.reflect=ALL-UNNAMED", \
+    "--add-opens", "java.base/java.nio=ALL-UNNAMED", \
+    "-jar", "/codbex-kronos.jar"]


### PR DESCRIPTION
New terminal (missing coloring): 
<img width="496" height="243" alt="image" src="https://github.com/user-attachments/assets/4c68957d-eb44-4f8c-9ef6-f48e39b14638" />


Terminal in `ghcr.io/codbex/codbex-kronos:2.100.0`:
<img width="507" height="239" alt="image" src="https://github.com/user-attachments/assets/ba04f7ec-cb7d-44ed-b541-0aa56e618aab" />
